### PR TITLE
Allow setting `access_log` to "off"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.x (Unreleased)
+
+ENHANCEMENTS:
+
+*   Improve configuration templating capabilities:
+    *   Allow setting `access_log`/`access_log_location` to `off`.
+
 ## 0.1.0 (August 19, 2020)
 
 Initial release of the NGINX Config role. Contains all NGINX Config related features previously available on the [NGINX Ansible role](https://github.com/nginxinc/ansible-role-nginx).

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -94,6 +94,7 @@ nginx_config_http_template:
         include_files: []
         http_error_pages: {}
         error_page: /usr/share/nginx/html
+        # access_log: "off" # Cancels all access_log directives on the current level
         access_log:
           - name: main
             location: /var/log/nginx/access.log

--- a/molecule/common/playbooks/default_converge.yml
+++ b/molecule/common/playbooks/default_converge.yml
@@ -76,6 +76,9 @@
                 http_error_pages:
                   404: /404.html
                 error_page: /usr/share/nginx/html
+                access_log:
+                  - name: main
+                    location: /var/log/nginx/access.log
                 client_max_body_size: 512k
                 proxy_hide_headers:
                   - X-Powered-By
@@ -254,6 +257,7 @@
                     opts: []
                 server_name: localhost
                 error_page: /usr/share/nginx/html
+                access_log: "off"
                 autoindex: false
                 sub_filter:
                   sub_filters:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -491,9 +491,13 @@ server {
 {% endif %}
 
 {% if item.value.servers[server].access_log is defined %}
+{% if item.value.servers[server].access_log is sameas false or item.value.servers[server].access_log == "off" %}
+    access_log off;
+{% else %}
 {% for access_log in item.value.servers[server].access_log %}
     access_log  {{ access_log.location }}  {{ access_log.name }};
 {% endfor %}
+{% endif %}
 {% endif %}
 {% if item.value.servers[server].error_log is defined %}
     error_log {{ item.value.servers[server].error_log.location }} {{ item.value.servers[server].error_log.level }};

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -66,9 +66,15 @@ http {
     log_format  {{ access_log.name }}  {{ access_log.format }};
 {% endfor %}
 
+{% if nginx_config_main_template.http_settings.access_log_location is defined %}
+{% if nginx_config_main_template.http_settings.access_log_location is sameas false or nginx_config_main_template.http_settings.access_log_location == "off" %}
+    access_log off;
+{% else %}
 {% for access_log in nginx_config_main_template.http_settings.access_log_location %}
     access_log  {{ access_log.location }}  {{ access_log.name }};
 {% endfor %}
+{% endif %}
+{% endif %}
 
     sendfile        on;
 


### PR DESCRIPTION
### Proposed changes
Allow setting `access_log` to "off".

So it will be possible to use this option as before:
```yaml
...
    access_log:
      - name: main
        location: /var/log/nginx/access.log
```
Or set it to `off` or `false` to cancel all access_log directives on the current level:
```yaml
...
    access_log: "off"
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/master/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)

_Copy of https://github.com/nginxinc/ansible-role-nginx/pull/304_