### PR TITLE
Fix configs cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ENHANCEMENTS:
 
-*   Update Ansible to `2.9.12` and Ansible Lint to `4.3.3`.
+*   Update Ansible to `2.9.13` and Ansible Lint to `4.3.4`.
 *   Explicitly defined `mode` in relevant tasks.
 *   Improve configuration templating capabilities:
     *   Allow setting `access_log`/`access_log_location` to `off`.
     *   Add IP restriction for web servers
+
+BUG FIXES:
+
+*   An empty `nginx_config_cleanup_files` will no longer cause `nginx_config_cleanup` related tasks to fail.
 
 ## 0.1.0 (August 19, 2020)
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -17,15 +17,15 @@ nginx_config_modules:
   rtmp: false
   xslt: false
 
-# Remove previously existing NGINX configuration files.
+# Remove previously existing NGINX configuration files (files ending in *.conf).
 # You can specify a list of paths you wish to remove.
 # You can also choose whether to recurse through the paths specified.
 # Alternatively you can specify the list of files you wish to remove.
 # Default is false.
 nginx_config_cleanup: false
-nginx_config_cleanup_paths:
-  - directory:
-      - /etc/nginx/conf.d
-    recurse: false
+# nginx_config_cleanup_paths:
+#   - directory:
+#       - /etc/nginx/conf.d
+#     recurse: false
 # nginx_config_cleanup_files:
 #   - /etc/nginx/conf.d/default.conf

--- a/tasks/conf/cleanup-config.yml
+++ b/tasks/conf/cleanup-config.yml
@@ -14,4 +14,4 @@
     state: absent
   loop: >-
     {{ nginx_config_files.results | default('') | map(attribute='files') | sum(start=[]) | map(attribute='path') | list
-    + nginx_config_cleanup_files | default('') }}
+    + nginx_config_cleanup_files | default('') | list }}


### PR DESCRIPTION
### Proposed changes
Ensure that if `nginx_config_cleanup_files` is not defined, the default value will be transformed into a list. Fixes #15. 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/master/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [ ] I have checked that all Molecule tests pass after adding my changes
-   [ ] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
