### PR TITLE
Add RHEL 8 to Galaxy's metadata to include and bump Ansible Lint to 4.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 install:
   - pip install ansible==2.9.13
-  - pip install ansible-lint==4.3.3
+  - pip install ansible-lint==4.3.4
   - pip install molecule==3.0.8
   - pip install docker==4.3.1
 script:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,6 +27,7 @@ galaxy_info:
       versions:
         - 6
         - 7
+        - 8
     - name: FreeBSD
       versions:
         - 11.2


### PR DESCRIPTION
### Proposed changes
Add RHEL 8 to Galaxy's metadata to include and bump Ansible Lint to 4.3.4. (I bumped the version in #19 Changelog but forgot to actually bump the version in TravisCI.)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/master/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [ ] I have checked that all Molecule tests pass after adding my changes
-   [ ] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
