### PR TITLE
Fixes #28: Use port 8080 by default for status page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
       env:
         scenario: default
     - name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
+      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
       env:
         scenario: plus
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Install stable branch and push a config

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       env:
         scenario: default
     - name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
-      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
+      if: env(NGINX_CRT) != "" and env(NGINX_KEY) != ""
       env:
         scenario: plus
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Install stable branch and push a config

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ jobs:
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Test config generation
       env:
         scenario: default
-    - name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
-      if: env(NGINX_CRT) != "" and env(NGINX_KEY) != ""
+    - if: env(NGINX_CRT) != "" and env(NGINX_KEY) != ""
+      name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
       env:
         scenario: plus
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Install stable branch and push a config

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Test config generation
       env:
         scenario: default
-    - if: $TRAVIS_PULL_REQUEST is false
+    - if: not (type = "pull_request" and fork = "true")
       name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
       env:
         scenario: plus

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Test config generation
       env:
         scenario: default
-    - if: env(NGINX_CRT) != "" and env(NGINX_KEY) != ""
+    - if: $TRAVIS_PULL_REQUEST is false
       name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
       env:
         scenario: plus

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ jobs:
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Test config generation
       env:
         scenario: default
-    - if: not (type = "pull_request" and fork = "true")
-      name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
+    - name: (CentOS/Debian/Ubuntu) Test config generation with NGINX Plus directives
+      if: not (type = "pull_request" and fork = "true")
       env:
         scenario: plus
     - name: (Alpine Linux/CentOS/Debian/Ubuntu) Install stable branch and push a config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.1 (September 28, 2020)
+## 0.3.0 (Unreleased)
 
 BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## 0.2.1 (September 28, 2020)
+
 BREAKING CHANGES:
 
 * The default port of the status module is now 8080 and matches the CI molecule test which already used it. Set ```nginx_config_status_port```to another desired value.
+
+BUG FIXES:
+
+*   Prevent TravisCI from trying to build (and failing) NGINX Plus images on external PRs.
 
 ## 0.2.0 (September 24, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 (September 28, 2020)
+BREAKING CHANGES:
+
+* The default port of the status module is now 8080 and matches the CI molecule test which already used it. Set ```nginx_config_status_port```to another desired value.
+
 ## 0.2.0 (September 24, 2020)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BREAKING CHANGES:
 
-* The default port of the status module is now 8080 and matches the CI molecule test which already used it. Set ```nginx_config_status_port```to another desired value.
+*   The default port of the status module is now 8080 and matches the CI molecule test which already used it. Set ```nginx_config_status_port```to another desired value.
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -361,7 +361,7 @@ nginx_config_status_enable: false
 nginx_config_status_template_file: http/status.conf.j2
 nginx_config_status_file_location: /etc/nginx/conf.d/status.conf
 nginx_config_status_log: false
-nginx_config_status_port: 80
+nginx_config_status_port: 8080
 nginx_config_status_allow: 127.0.0.1
 nginx_config_status_deny: all
 

--- a/templates/http/status.conf.j2
+++ b/templates/http/status.conf.j2
@@ -1,15 +1,15 @@
 {{ ansible_managed | comment }}
 
 server {
-    listen {{ nginx_config_status_port | default('80') }};
+    listen {{ nginx_config_status_port | default('8080') }};
     access_log {{ nginx_config_status_log | ternary('on', 'off') }};
     location /nginx_status {
         stub_status on;
+    }
 {% if nginx_config_status_allow is defined %}
-        allow {{ nginx_config_status_allow }};
+    allow {{ nginx_config_status_allow }};
 {% endif %}
 {% if nginx_config_status_deny is defined %}
-        deny {{ nginx_config_status_deny }};
+    deny {{ nginx_config_status_deny }};
 {% endif %}
-    }
 }


### PR DESCRIPTION
### Proposed changes
Fixes #28 by making 8080 the default port for the status page. Moved the status page ACL out of the location block to server to ensure it's applied to all requests. 
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works (Molecule [test](https://github.com/nginxinc/ansible-role-nginx-config/blob/6b7e1e9156c9b1f350a6f68dc2c2a6933faa126b/molecule/default/converge.yml#L60) already used 8080)
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
