### PR TITLE
Missing semicolon fix

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -15,7 +15,7 @@ worker_rlimit_nofile {{ nginx_config_main_template.worker_rlimit_nofile }};
 
 {% if nginx_config_main_template.custom_options is defined and nginx_config_main_template.custom_options | length %}
 {% for inline_option in nginx_config_main_template.custom_options %}
-{{ inline_option }}
+{{ inline_option }};
 {% endfor %}
 {% endif %}
 
@@ -27,7 +27,7 @@ events {
     worker_connections  {{ nginx_config_main_template.worker_connections }};
 {% if nginx_config_main_template.events_custom_options is defined and nginx_config_main_template.events_custom_options | length %}
 {% for inline_option in nginx_config_main_template.events_custom_options %}
-    {{ inline_option }}
+    {{ inline_option }};
 {% endfor %}
 {% endif %}
 }
@@ -126,7 +126,7 @@ http {
 stream {
 {% if nginx_config_main_template.stream_custom_options is defined and nginx_config_main_template.stream_custom_options | length %}
 {% for inline_option in nginx_config_main_template.stream_custom_options %}
-    {{ inline_option }}
+    {{ inline_option }};
 {% endfor %}
 {% endif %}
     include /etc/nginx/conf.d/stream/*.conf;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -110,7 +110,7 @@ http {
 {% endif %}
 {% if nginx_config_main_template.http_custom_options is defined and nginx_config_main_template.http_custom_options | length %}
 {% for inline_option in nginx_config_main_template.http_custom_options %}
-    {{ inline_option }}
+    {{ inline_option }};
 {% endfor %}
 {% endif %}
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
### Proposed changes
Semicolon missing in the main config template for custom options. Variables have to be defined with a ; at the and of the value.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
