### PR TITLE
SELinux state should now be correctly set back to `enforcing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 *   Switch to explicit boolean values in `sub_filter` defaults for `last_modified` and `since` in `nginx_config_main_template`. `"on"` and `"off"` values are treated as true instead of true/false when surrounded by double quotes. By always resorting to true/false we avoid unaccounted edge cases.
+*   Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_config_selinux: true`.
 
 ## 0.3.0 (November 17, 2020)
 

--- a/defaults/main/selinux.yml
+++ b/defaults/main/selinux.yml
@@ -1,7 +1,7 @@
 ---
 # Set SELinux enforcing for NGINX (Centos/Redhat only) - you may need to open ports on your own
 nginx_config_selinux: false
-# Enable enforcing mode if true. Permissive if false (audit only, no enforcing) globally (only works with nginx_unit_selinux: true)
+# Enable enforcing mode if true. Permissive if false (audit only, no enforcing) globally (only works with nginx_config_selinux: true)
 nginx_config_selinux_enforcing: true
 # List of TCP ports to add to http_port_t type (80 and 443 have this type already)
 # nginx_config_selinux_tcp_ports:

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -21,8 +21,6 @@
   selinux:
     state: permissive
     policy: targeted
-  changed_when: false
-  when: ansible_facts['selinux']['mode'] == "enforcing"
 
 - name: Allow SELinux HTTP network connections
   seboolean:
@@ -72,7 +70,4 @@
   selinux:
     state: enforcing
     policy: targeted
-  changed_when: false
-  when:
-    - nginx_config_selinux_enforcing
-    - ansible_facts['selinux']['mode'] == "permissive"
+  when: nginx_config_selinux_enforcing


### PR DESCRIPTION
### Proposed changes
Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_config_selinux: true`. Fixes #46.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
