### PR TITLE
Fix #50: Add upstream server backup parameter to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ENHANCEMENTS:
 
 *   Add support for NGINX GRPC directives.
+*   Added support for upstream server `backup` parameter in http and stream template.
 *   Only run GitHub actions Galaxy CI/CD workflow when a new release is published.
 *   Update list of supported platforms.
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -289,6 +289,10 @@
                     address: 0.0.0.0
                     port: 8083
                     down: true
+                  backend_server_4:
+                    address: 0.0.0.0
+                    port: 8084
+                    backup: true
           frontend:
             template_file: http/default.conf.j2
             conf_file_name: frontend_default.conf
@@ -432,3 +436,7 @@
                     address: 0.0.0.0
                     port: 9092
                     down: true
+                  backend_server_3:
+                    address: 0.0.0.0
+                    port: 8083
+                    backup: true

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -275,6 +275,10 @@
                     address: 0.0.0.0
                     port: 8083
                     down: true
+                  backend_server_4:
+                    address: 0.0.0.0
+                    port: 8084
+                    backup: true
           frontend:
             template_file: http/default.conf.j2
             conf_file_name: frontend_default.conf
@@ -418,3 +422,7 @@
                     address: 0.0.0.0
                     port: 9092
                     down: true
+                  backend_server_3:
+                    address: 0.0.0.0
+                    port: 8083
+                    backup: true

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -10,7 +10,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% endif %}
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
+    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].backup is defined and item.value.upstreams[upstream].servers[server].backup %}backup{% endif %} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie is defined and item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;

--- a/templates/stream/default.conf.j2
+++ b/templates/stream/default.conf.j2
@@ -8,7 +8,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endif %}
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
+    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].backup is defined and item.value.upstreams[upstream].servers[server].backup %}backup{% endif %} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie is defined %}
 {% if item.value.upstreams[upstream].sticky_cookie %}


### PR DESCRIPTION
### Proposed changes
Added support for `backspin the default templates for http and stream. Parameter as explained by Nginx doc:
```shell
marks the server as a backup server. Connections to the backup server will be passed when the primary servers are unavailable.
```

### Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
