### PR TITLE
Rename `proxy_hide_headers` to `proxy_hide_header`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0 (Unreleased)
+
+BREAKING CHANGES:
+
+Rename `proxy_hide_headers` to `proxy_hide_header` to align with NGINX directive names.
+
 ## 0.3.3 (Unreleased)
 
 FEATURES:

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -228,7 +228,7 @@ nginx_config_http_template:
         #   name: $auth_user
         #   value: $upstream_http_x_user
         client_max_body_size: 1m
-        proxy_hide_headers: []  # A list of headers which shouldn't be passed to the application
+        proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
         add_headers:
           strict_transport_security:
             name: Strict-Transport-Security
@@ -269,7 +269,7 @@ nginx_config_http_template:
               #   types: []  # Optional list
               #   vary: false  # Optional
               include_files: []
-              proxy_hide_headers: []  # A list of headers which shouldn't be passed to the application
+              proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
               add_headers:
                 strict_transport_security:
                   name: Strict-Transport-Security
@@ -363,7 +363,7 @@ nginx_config_http_template:
               #   types: []  # Optional list
               #   vary: false  # Optional
               include_files: []
-              proxy_hide_headers: []  # A list of headers which shouldn't be passed to the application
+              proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
               add_headers:
                 strict_transport_security:
                   name: Strict-Transport-Security

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -140,7 +140,7 @@
                   - name: main
                     location: /var/log/nginx/access.log
                 client_max_body_size: 512k
-                proxy_hide_headers:
+                proxy_hide_header:
                   - X-Powered-By
                 add_headers:
                   strict_transport_security:
@@ -156,7 +156,7 @@
                       location: /
                       grpc:
                         pass: localhost:9000
-                      proxy_hide_headers:
+                      proxy_hide_header:
                         - X-Powered-By
                       add_headers:
                         strict_transport_security:
@@ -340,7 +340,7 @@
                   locations:
                     frontend_site:
                       location: /
-                      proxy_hide_headers:
+                      proxy_hide_header:
                         - X-Powered-By
                       html_file_location: /usr/share/nginx/html
                       html_file_name: frontend_index.html

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -110,7 +110,7 @@
                   - name: main
                     location: /var/log/nginx/access.log
                 client_max_body_size: 512k
-                proxy_hide_headers:
+                proxy_hide_header:
                   - X-Powered-By
                 add_headers:
                   strict_transport_security:
@@ -127,7 +127,7 @@
                       app_protect:
                         enable: true
                         policy_file: /etc/nginx/app-protect-security-policy.json
-                      proxy_hide_headers:
+                      proxy_hide_header:
                         - X-Powered-By
                       add_headers:
                         strict_transport_security:
@@ -312,7 +312,7 @@
                   locations:
                     frontend_site:
                       location: /
-                      proxy_hide_headers:
+                      proxy_hide_header:
                         - X-Powered-By
                       html_file_location: /usr/share/nginx/html
                       html_file_name: frontend_index.html

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -146,8 +146,8 @@ server {
     include "{{ file }}";
 {% endfor %}
 {% endif %}
-{% if item.value.servers[server].proxy_hide_headers is defined %}
-{% for header in item.value.servers[server].proxy_hide_headers %}
+{% if item.value.servers[server].proxy_hide_header is defined %}
+{% for header in item.value.servers[server].proxy_hide_header %}
     proxy_hide_header {{ header }};
 {% endfor %}
 {% endif %}
@@ -238,8 +238,8 @@ server {
         include "{{ file }}";
 {% endfor %}
 {% endif %}
-{% if item.value.servers[server].reverse_proxy.locations[location].proxy_hide_headers is defined %}
-{% for header in item.value.servers[server].reverse_proxy.locations[location].proxy_hide_headers %}
+{% if item.value.servers[server].reverse_proxy.locations[location].proxy_hide_header is defined %}
+{% for header in item.value.servers[server].reverse_proxy.locations[location].proxy_hide_header %}
         proxy_hide_header {{ header }};
 {% endfor %}
 {% endif %}
@@ -470,8 +470,8 @@ server {
         {{ inline_option }}
 {% endfor %}
 {% endif %}
-{% if item.value.servers[server].web_server.locations[location].proxy_hide_headers is defined %}
-{% for header in item.value.servers[server].web_server.locations[location].proxy_hide_headers %}
+{% if item.value.servers[server].web_server.locations[location].proxy_hide_header is defined %}
+{% for header in item.value.servers[server].web_server.locations[location].proxy_hide_header %}
         proxy_hide_header {{ header }};
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
### Proposed changes
Rename `proxy_hide_headers` to `proxy_hide_header` to align with NGINX directive names. Closes #51.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
