### PR TITLE
Make `proxy_pass` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ ENHANCEMENTS:
 *   Update list of supported platforms.
 *   Update Ansible base to `2.10.5` and Ansible to `2.10.6`.
 
+BUG FIXES:
+
+Fix edge case where `proxy_pass` is still required when using `grpc_pass`.
+
 ## 0.3.2 (January 11, 2021)
 
 ENHANCEMENTS:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -282,7 +282,9 @@ server {
 {% if item.value.servers[server].reverse_proxy.locations[location].proxy_connect_timeout is defined and item.value.servers[server].reverse_proxy.locations[location].proxy_connect_timeout %}
         proxy_connect_timeout {{ item.value.servers[server].reverse_proxy.locations[location].proxy_connect_timeout }};
 {% endif %}
-        proxy_pass {{ item.value.servers[server].reverse_proxy.locations[location].proxy_pass }};
+{% if item.value.servers[server].reverse_proxy.locations[location].proxy_pass is defined %}
+proxy_pass {{ item.value.servers[server].reverse_proxy.locations[location].proxy_pass }};
+{% endif %}
 {% if item.value.servers[server].reverse_proxy.locations[location].rewrites is defined %}
 {% for rewrite in item.value.servers[server].reverse_proxy.locations[location].rewrites %}
         rewrite {{ rewrite }};


### PR DESCRIPTION
### Proposed changes
Fix edge case where `proxy_pass` is still required when using `grpc_pass`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [ ] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
