### PR TITLE
Change directory to `/etc/nginx` before running NGINX config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ BREAKING CHANGES:
 
 DEPRECATION WARNINGS:
 
-The `nginx_config_main_upload_*`, `nginx_config_upload_html_*`, and `nginx_config_stream_upload_*` parameters have been deprecated in favor of a newly introduced parameter, `nginx_config_upload_*` (previously `nginx_config_snippet_upload_*`). The new parameter provides greater flexibility in configuring your upload settings in addition to simplifying the upload Ansible tasks. The depecrated parameters will be removed in the next major release (0.5.0), due April 2021.
+The `nginx_config_main_upload_*`, `nginx_config_upload_html_*`, and `nginx_config_stream_upload_*` parameters have been deprecated in favor of a newly introduced parameter, `nginx_config_upload_*` (previously `nginx_config_snippet_upload_*`). The new parameter provides greater flexibility in configuring your upload settings in addition to simplifying the upload Ansible tasks. The deprecated parameters will be removed in the next major release (0.5.0), due April 2021.
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-Add `state` parameter to package module in Molecule verification tests.
+*   Add `state` parameter to package module in Molecule verification tests.
+*   In App Protect environments on SELinux enforced systems, the `nginx -t` handler fails when run from a directory that the nginx process' user does not have access to.
 
 ## 0.3.3 (January 28, 2021)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: (Handler - NGINX Config) Check NGINX
   command: nginx -t
+  args:
+    chdir: /etc/nginx/
   register: config_check
   ignore_errors: yes
   check_mode: no


### PR DESCRIPTION
### Proposed changes
In App Protect environments on SELinux enforced systems, the `nginx -t` handler fails when run from a directory that the nginx process' user does not have access to. Fix: cd to etc nginx before running test command.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [X] I have checked that all Molecule tests pass after adding my changes
-   [X] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
