### PR TITLE
Refactor HTTP Upstream module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ BREAKING CHANGES:
 *   Refactor the config templates to simplify the creation of templates as well as development and maintenance moving forward:
     *   Modify `servers`, `servers.listen`, `server.locations`, `upstream` and `upstream.servers` from nested dictionaries in the `http` and `stream` configuration templates to lists, as well as modify the `nginx_config_html_demo_template` variable from a nested dictionary to a list. To update your templates, replace the aforementioned nested dictionary keys by lists (place a dash in front of the topmost nested value within each aforementioned nested dictionary).
     *   Remove/merge the `web_server` and `reverse_proxy` nested dictionary keys from the HTTP templates. These often lead to confusing and unnecessary code duplication and hard to maintain code. To update your templates, remove both keys and adjust your spacing accordingly.
+*   Refactor the `upstream` HTTP config template into its own separate file. The following variables have changed (check `defaults/main/template.yml` for example values):
+    *   `port` is no longer supported. Instead, include the port as part of your `address`.
+    *   `lb_method` is no longer supported. Instead, you will have to specifically set the method you want to use.
+    *   `zone_name` and `zone_size` have been modified into a dictionary.
+    *   `sticky_cookie` is no longer supported as is. You will now have to configure the `sticky_cookie` values.
+    *   The `health_check` parameter within the `server` dictionary is no longer supported. Instead, manually set `max_fails` and `fail_timeout`.
 *   Rename some NGINX template config parameters to align with NGINX directive names:
     *   Rename `proxy_hide_headers` to `proxy_hide_header`.
     *   Rename `html_file_location` to `root`.

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -26,69 +26,69 @@ nginx_config_main_template:
   worker_connections: 1024
   http_enable: true
   http_settings:
-    # app_protect_global:  # Optional -- Configure NGINX App Protect
-    #   physical_memory_util_thresholds:  # Optional
-    #     high: 100  # Required
-    #     low: 100  # Required
-    #   cpu_thresholds:  # Optional
-    #     high: 100  # Required
-    #     low: 100  # Required
-    #   failure_mode_action: pass  # Optional -- 'pass' or 'drop'
-    #   cookie_seed: encryptionseed  # Optional
-    #   compressed_requests_action: drop  # Optional -- 'pass' or 'drop'
-    #   request_buffer_overflow_action: pass  # Optional -- 'pass' or 'drop'
-    #   user_defined_signatures: []  # Optional list
-    # app_protect:  # Optional -- Configure NGINX App Protect
-    #   enable: false  # Optional
-    #   policy_file: path  # Optional
-    #   security_log_enable: false  # Optional
-    #   security_log:  # Optional
-    #     path: path  # Required
-    #     destination: dest  # Required
-    # grpc_global:  # Optional -- Configure GRPC
-    #   bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
-    #     address: $remote_addr  # Required
-    #     transparent: true  # Optional
-    #   buffer_size: 4k  # Optional
-    #   connect_timeout: 60s  # Optional
-    #   hide_header: []  # Optional list
-    #   ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
-    #   intercept_errors: false  # Optional
-    #   next_upstream: []  # Optional list
-    #   next_upstream_timeout: 0  # Optional
-    #   next_upstream_tries: 0  # Optional
-    #   pass_header: []  # Optional list
-    #   read_timeout: 60s  # Optional
-    #   send_timeout: 60s  # Optional
-    #   set_header:  # Optional
-    #     - field: Accept-Encoding  # Required
-    #       value: '""'  # Required
-    #   socket_keepalive: false  # Optional
-    #   ssl_certificate: fileLocation  # Optional
-    #   ssl_certificate_key: fileLocation  # Optional
-    #   ssl_ciphers: DEFAULT  # Optional
-    #   ssl_conf_command: command  # Optional
-    #   ssl_crl: fileLocation  # Optional
-    #   ssl_name: serverName  # Optional
-    #   ssl_password_file: fileLocation  # Optional
-    #   ssl_protocols: []  # Optional list
-    #   ssl_server_name: false  # Optional
-    #   ssl_session_reuse: true  # Optional
-    #   ssl_trusted_certificate: fileLocation  # Optional
-    #   ssl_verify: false  # Optional
-    #   ssl_verify_depth: 1  # Optional
-    # gzip:  # Optional -- Configure GZIP
-    #   enable: true  # Optional
-    #   buffers:  # Optional
-    #     number: 32  # Required
-    #     size: 4k  # Required
-    #   comp_level: 1  # Optional
-    #   disable: []  # Optional list
-    #   http_version: 1.1  # Optional -- One of '1.0' or '1.1'
-    #   min_length: 20  # Optional
-    #   proxied: []  # Optional list
-    #   types: []  # Optional list
-    #   vary: false  # Optional
+    app_protect_global:  # Optional -- Configure NGINX App Protect
+      physical_memory_util_thresholds:  # Optional
+        high: 100  # Required
+        low: 100  # Required
+      cpu_thresholds:  # Optional
+        high: 100  # Required
+        low: 100  # Required
+      failure_mode_action: pass  # Optional -- 'pass' or 'drop'
+      cookie_seed: encryptionseed  # Optional
+      compressed_requests_action: drop  # Optional -- 'pass' or 'drop'
+      request_buffer_overflow_action: pass  # Optional -- 'pass' or 'drop'
+      user_defined_signatures: []  # Optional list
+    app_protect:  # Optional -- Configure NGINX App Protect
+      enable: false  # Optional
+      policy_file: path  # Optional
+      security_log_enable: false  # Optional
+      security_log:  # Optional
+        path: path  # Required
+        destination: dest  # Required
+    grpc_global:  # Optional -- Configure GRPC
+      bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
+        address: $remote_addr  # Required
+        transparent: true  # Optional
+      buffer_size: 4k  # Optional
+      connect_timeout: 60s  # Optional
+      hide_header: []  # Optional list
+      ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
+      intercept_errors: false  # Optional
+      next_upstream: []  # Optional list
+      next_upstream_timeout: 0  # Optional
+      next_upstream_tries: 0  # Optional
+      pass_header: []  # Optional list
+      read_timeout: 60s  # Optional
+      send_timeout: 60s  # Optional
+      set_header:  # Optional
+        - field: Accept-Encoding  # Required
+          value: '""'  # Required
+      socket_keepalive: false  # Optional
+      ssl_certificate: fileLocation  # Optional
+      ssl_certificate_key: fileLocation  # Optional
+      ssl_ciphers: DEFAULT  # Optional
+      ssl_conf_command: command  # Optional
+      ssl_crl: fileLocation  # Optional
+      ssl_name: serverName  # Optional
+      ssl_password_file: fileLocation  # Optional
+      ssl_protocols: []  # Optional list
+      ssl_server_name: false  # Optional
+      ssl_session_reuse: true  # Optional
+      ssl_trusted_certificate: fileLocation  # Optional
+      ssl_verify: false  # Optional
+      ssl_verify_depth: 1  # Optional
+    gzip:  # Optional -- Configure GZIP
+      enable: true  # Optional
+      buffers:  # Optional
+        number: 32  # Required
+        size: 4k  # Required
+      comp_level: 1  # Optional
+      disable: []  # Optional list
+      http_version: 1.1  # Optional -- One of '1.0' or '1.1'
+      min_length: 20  # Optional
+      proxied: []  # Optional list
+      types: []  # Optional list
+      vary: false  # Optional
     access_log_format:
       - name: main
         format: |-
@@ -137,57 +137,57 @@ nginx_config_http_template:
             port: 8081
             ssl: true
             opts: []  # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
-        # app_protect:  # Optional -- Configure NGINX App Protect
-        #   enable: false  # Optional
-        #   policy_file: path  # Optional
-        #   security_log_enable: false  # Optional
-        #   security_log:  # Optional
-        #     path: path  # Required
-        #     destination: dest  # Required
-        # grpc_global:  # Optional -- Configure GRPC
-        #   bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
-        #     address: $remote_addr  # Required
-        #     transparent: true  # Optional
-        #   buffer_size: 4k  # Optional
-        #   connect_timeout: 60s  # Optional
-        #   hide_header: []  # Optional list
-        #   ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
-        #   intercept_errors: false  # Optional
-        #   next_upstream: []  # Optional list
-        #   next_upstream_timeout: 0  # Optional
-        #   next_upstream_tries: 0  # Optional
-        #   pass_header: []  # Optional list
-        #   read_timeout: 60s  # Optional
-        #   send_timeout: 60s  # Optional
-        #   set_header:  # Optional
-        #     - field: Accept-Encoding  # Required
-        #       value: '""'  # Required
-        #   socket_keepalive: false  # Optional
-        #   ssl_certificate: fileLocation  # Optional
-        #   ssl_certificate_key: fileLocation  # Optional
-        #   ssl_ciphers: DEFAULT  # Optional
-        #   ssl_conf_command: command  # Optional
-        #   ssl_crl: fileLocation  # Optional
-        #   ssl_name: serverName  # Optional
-        #   ssl_password_file: fileLocation  # Optional
-        #   ssl_protocols: []  # Optional list
-        #   ssl_server_name: false  # Optional
-        #   ssl_session_reuse: true  # Optional
-        #   ssl_trusted_certificate: fileLocation  # Optional
-        #   ssl_verify: false  # Optional
-        #   ssl_verify_depth: 1  # Optional
-        # gzip:  # Optional -- Configure GZIP
-        #   enable: true  # Optional
-        #   buffers:  # Optional
-        #     number: 32  # Required
-        #     size: 4k  # Required
-        #   comp_level: 1  # Optional
-        #   disable: []  # Optional list
-        #   http_version: 1.1  # Optional -- One of '1.0' or '1.1'
-        #   min_length: 20  # Optional
-        #   proxied: []  # Optional list
-        #   types: []  # Optional list
-        #   vary: false  # Optional
+        app_protect:  # Optional -- Configure NGINX App Protect
+          enable: false  # Optional
+          policy_file: path  # Optional
+          security_log_enable: false  # Optional
+          security_log:  # Optional
+            path: path  # Required
+            destination: dest  # Required
+        grpc_global:  # Optional -- Configure GRPC
+          bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
+            address: $remote_addr  # Required
+            transparent: true  # Optional
+          buffer_size: 4k  # Optional
+          connect_timeout: 60s  # Optional
+          hide_header: []  # Optional list
+          ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
+          intercept_errors: false  # Optional
+          next_upstream: []  # Optional list
+          next_upstream_timeout: 0  # Optional
+          next_upstream_tries: 0  # Optional
+          pass_header: []  # Optional list
+          read_timeout: 60s  # Optional
+          send_timeout: 60s  # Optional
+          set_header:  # Optional
+            - field: Accept-Encoding  # Required
+              value: '""'  # Required
+          socket_keepalive: false  # Optional
+          ssl_certificate: fileLocation  # Optional
+          ssl_certificate_key: fileLocation  # Optional
+          ssl_ciphers: DEFAULT  # Optional
+          ssl_conf_command: command  # Optional
+          ssl_crl: fileLocation  # Optional
+          ssl_name: serverName  # Optional
+          ssl_password_file: fileLocation  # Optional
+          ssl_protocols: []  # Optional list
+          ssl_server_name: false  # Optional
+          ssl_session_reuse: true  # Optional
+          ssl_trusted_certificate: fileLocation  # Optional
+          ssl_verify: false  # Optional
+          ssl_verify_depth: 1  # Optional
+        gzip:  # Optional -- Configure GZIP
+          enable: true  # Optional
+          buffers:  # Optional
+            number: 32  # Required
+            size: 4k  # Required
+          comp_level: 1  # Optional
+          disable: []  # Optional list
+          http_version: 1.1  # Optional -- One of '1.0' or '1.1'
+          min_length: 20  # Optional
+          proxied: []  # Optional list
+          types: []  # Optional list
+          vary: false  # Optional
         ssl:
           cert: /etc/ssl/certs/default.crt
           key: /etc/ssl/private/default.key
@@ -247,59 +247,59 @@ nginx_config_http_template:
         http_demo_conf: false
         locations:
           - location: /
-            # app_protect:  # Optional -- Configure NGINX App Protect
-            #   enable: false  # Optional
-            #   policy_file: path  # Optional
-            #   security_log_enable: false  # Optional
-            #   security_log:  # Optional
-            #     path: path  # Required
-            #     destination: dest  # Required
-            # grpc_global:  # Optional -- Configure GRPC
-            #   bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
-            #     address: $remote_addr  # Required
-            #     transparent: true  # Optional
-            #   buffer_size: 4k  # Optional
-            #   connect_timeout: 60s  # Optional
-            #   hide_header: []  # Optional list
-            #   ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
-            #   intercept_errors: false  # Optional
-            #   next_upstream: []  # Optional list
-            #   next_upstream_timeout: 0  # Optional
-            #   next_upstream_tries: 0  # Optional
-            #   pass_header: []  # Optional list
-            #   read_timeout: 60s  # Optional
-            #   send_timeout: 60s  # Optional
-            #   set_header:  # Optional
-            #     - field: Accept-Encoding  # Required
-            #       value: '""'  # Required
-            #   socket_keepalive: false  # Optional
-            #   ssl_certificate: fileLocation  # Optional
-            #   ssl_certificate_key: fileLocation  # Optional
-            #   ssl_ciphers: DEFAULT  # Optional
-            #   ssl_conf_command: command  # Optional
-            #   ssl_crl: fileLocation  # Optional
-            #   ssl_name: serverName  # Optional
-            #   ssl_password_file: fileLocation  # Optional
-            #   ssl_protocols: []  # Optional list
-            #   ssl_server_name: false  # Optional
-            #   ssl_session_reuse: true  # Optional
-            #   ssl_trusted_certificate: fileLocation  # Optional
-            #   ssl_verify: false  # Optional
-            #   ssl_verify_depth: 1  # Optional
-            # grpc:  # Optional -- Configure GRPC
-            #   pass: localhost:9000  # Optional
-            # gzip:  # Optional -- Configure GZIP
-            #   enable: true  # Optional
-            #   buffers:  # Optional
-            #     number: 32  # Required
-            #     size: 4k  # Required
-            #   comp_level: 1  # Optional
-            #   disable: []  # Optional list
-            #   http_version: 1.1  # Optional -- One of '1.0' or '1.1'
-            #   min_length: 20  # Optional
-            #   proxied: []  # Optional list
-            #   types: []  # Optional list
-            #   vary: false  # Optional
+            app_protect:  # Optional -- Configure NGINX App Protect
+              enable: false  # Optional
+              policy_file: path  # Optional
+              security_log_enable: false  # Optional
+              security_log:  # Optional
+                path: path  # Required
+                destination: dest  # Required
+            grpc_global:  # Optional -- Configure GRPC
+              bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
+                address: $remote_addr  # Required
+                transparent: true  # Optional
+              buffer_size: 4k  # Optional
+              connect_timeout: 60s  # Optional
+              hide_header: []  # Optional list
+              ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
+              intercept_errors: false  # Optional
+              next_upstream: []  # Optional list
+              next_upstream_timeout: 0  # Optional
+              next_upstream_tries: 0  # Optional
+              pass_header: []  # Optional list
+              read_timeout: 60s  # Optional
+              send_timeout: 60s  # Optional
+              set_header:  # Optional
+                - field: Accept-Encoding  # Required
+                  value: '""'  # Required
+              socket_keepalive: false  # Optional
+              ssl_certificate: fileLocation  # Optional
+              ssl_certificate_key: fileLocation  # Optional
+              ssl_ciphers: DEFAULT  # Optional
+              ssl_conf_command: command  # Optional
+              ssl_crl: fileLocation  # Optional
+              ssl_name: serverName  # Optional
+              ssl_password_file: fileLocation  # Optional
+              ssl_protocols: []  # Optional list
+              ssl_server_name: false  # Optional
+              ssl_session_reuse: true  # Optional
+              ssl_trusted_certificate: fileLocation  # Optional
+              ssl_verify: false  # Optional
+              ssl_verify_depth: 1  # Optional
+            grpc:  # Optional -- Configure GRPC
+              pass: localhost:9000  # Optional
+            gzip:  # Optional -- Configure GZIP
+              enable: true  # Optional
+              buffers:  # Optional
+                number: 32  # Required
+                size: 4k  # Required
+              comp_level: 1  # Optional
+              disable: []  # Optional list
+              http_version: 1.1  # Optional -- One of '1.0' or '1.1'
+              min_length: 20  # Optional
+              proxied: []  # Optional list
+              types: []  # Optional list
+              vary: false  # Optional
             include_files: []
             proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
             add_headers:
@@ -417,18 +417,68 @@ nginx_config_http_template:
         - timeout
       proxy_ignore_headers:
         - Expires
-    upstreams:
-      - name: backend
-        lb_method: least_conn
-        zone_name: backend_mem_zone
-        zone_size: 64k
-        sticky_cookie: false
-        servers:
-          - address: localhost
-            port: 8081
-            weight: 1
-            health_check: max_fails=1 fail_timeout=10s
-        # custom_options: []
+    upstreams:  # Optional -- Configure NGINX Upstreams
+      - name: backend  # Required
+        servers:  # Optional -- Cannot be used if 'state' directive is defined
+          - address: localhost  # Required -- You can use an IP address, a Unix socket, or a domain -- include port details inline if necessary
+            weight: 1  # Optional
+            max_conns: 0  # Optional
+            max_fails: 1  # Optional
+            fail_timeout: 10s  # Optional
+            backup: false  # Optional
+            down: false  # Optional
+            resolve: false  # Optional -- Requires 'resolver' directive to be defined
+            route: a  # Optional -- Requires 'sticky route' directive to be defined
+            service: http  # Optional --  Requires 'resolve' parameter to be set
+            slow_start: 0s  # Optional
+            drain: false  # Optional
+        zone:  # Optional
+          name: backend_mem_zone  # Required
+          size: 64k  # Optional
+        state: /var/lib/nginx/state/servers.conf  # Optional -- Cannot be used if 'servers' directive is defined
+        hash:  # Optional -- You can only set one load balancing method -- 'round_robin' is used if no method is specified
+          key: key  # Required
+          consistent: false  # Optional
+        ip_hash: false  # Optional
+        least_conn: false  # Optional
+        least_time:  # Optional
+          response: last_byte  # Required -- One of 'header' or 'last_byte'
+          inflight: false  # Optional
+        random:  # Optional
+          two: true  # Optional
+          method: least_time=last_byte  # Optional -- Requires two to be set to true
+        queue:  # Optional
+          number: 10  # Required
+          timeout: 60s  # Optional
+        keepalive: 32  # Optional
+        keepalive_requests: 100  # Optional
+        keepalive_timeout: 60s  # Optional
+        ntlm: false  # Optional
+        resolver:  # Optional
+          address: []  # Required
+          valid: 30s  # Optional
+          ipv6: false  # Optional
+          status_zone: backend_mem_zone  # Optional
+        resolver_timeout: 30s  # Optional
+        sticky_cookie:  # Optional -- You can only set one type of sticky session affinity
+          name: cookie  # Required
+          expires: 1d  # Optional
+          domain: example.com  # Optional
+          httponly: false  # Optional
+          samesite: none  # Optional -- One of 'strict', 'lax' or 'none'
+          secure: true  # Optional
+          path: /  # Optional
+        sticky_route: []  # Optional
+        sticky_learn:  # Optional
+          create: []  # Required
+          lookup: []  # Required
+          zone:  # Required
+            name: client_sessions
+            size: 1m
+          timeout: 10m  # Optional
+          header: false  # Optional
+          sync: false  # Optional
+        custom_directives: []
       # custom_options: []
 
 # Enable NGINX 'stub_status' data.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -264,33 +264,35 @@
                 - Expires
             upstreams:
               - name: frontend_servers
-                lb_method: least_conn
-                zone_name: frontend_mem_zone
-                zone_size: 64k
-                sticky_cookie: false
+                least_conn: true
+                zone:
+                  name: frontend_mem_zone
+                  size: 64k
+                keepalive: 32
+                keepalive_requests: 100
+                keepalive_timeout: 60s
                 servers:
-                  - address: 0.0.0.0
-                    port: 8081
+                  - address: 0.0.0.0:8081
                     weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
+                    max_fails: 3
+                    fail_timeout: 5s
               - name: backend_servers
-                lb_method: least_conn
-                zone_name: backend_mem_zone
-                zone_size: 64k
-                sticky_cookie: false
+                least_conn: true
+                zone:
+                  name: backend_mem_zone
+                  size: 64k
                 servers:
-                  - address: 0.0.0.0
-                    port: 8082
+                  - address: 0.0.0.0:8082
                     weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
+                    max_fails: 3
+                    fail_timeout: 5s
                   - address: unix:/var/run/control.unit.sock
                     weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
-                  - address: 0.0.0.0
-                    port: 8083
+                    max_fails: 3
+                    fail_timeout: 5s
+                  - address: 0.0.0.0:8083
                     down: true
-                  - address: 0.0.0.0
-                    port: 8084
+                  - address: 0.0.0.0:8084
                     backup: true
           - template_file: http/default.conf.j2
             conf_file_name: frontend_default.conf

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -235,34 +235,69 @@
                 - Expires
             upstreams:
               - name: frontend_servers
-                lb_method: least_conn
-                zone_name: frontend_mem_zone
-                zone_size: 64k
-                sticky_cookie: false
-                servers:
-                  - address: 0.0.0.0
-                    port: 8081
-                    weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
+                zone:
+                  name: frontend_mem_zone
+                  size: 64k
+                state: /var/lib/nginx/state/servers.conf
+                least_time:
+                  response: last_byte
+                  inflight: false
+                ntlm: true
+                queue:
+                  number: 10
+                  timeout: 60s
+                keepalive: 32
+                keepalive_requests: 100
+                keepalive_timeout: 60s
+                sticky_route:
+                  - $cookie_jsessionid
+                  - $request_uri
+                servers: []
               - name: backend_servers
-                lb_method: least_conn
-                zone_name: backend_mem_zone
-                zone_size: 64k
-                sticky_cookie: false
+                zone:
+                  name: backend_mem_zone
+                  size: 64k
+                random:
+                  two: true
+                  method: least_time=last_byte
+                sticky_learn:
+                  create:
+                    - $upstream_cookie_example_cookie
+                    - $upstream_cookie_example_biscuit
+                  lookup:
+                    - $cookie_examplecookie
+                  zone:
+                    name: client_sessions
+                    size: 1m
+                  timeout: 10m
+                  header: false
+                  sync: false
+                resolver:
+                  address:
+                    - 127.0.0.1
+                  valid: 30s
+                  ipv6: false
+                  status_zone: backend_mem_zone
+                resolver_timeout: 30s
                 servers:
-                  - address: 0.0.0.0
-                    port: 8082
+                  - address: 0.0.0.0:8082
                     weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
                   - address: unix:/var/run/control.unit.sock
                     weight: 1
-                    health_check: max_fails=3 fail_timeout=5s
-                  - address: 0.0.0.0
-                    port: 8083
+                  - address: 0.0.0.0:8083
                     down: true
-                  - address: 0.0.0.0
-                    port: 8084
-                    backup: true
+                  - address: example.com
+                    weight: 1
+                    max_conns: 0
+                    max_fails: 1
+                    fail_timeout: 10s
+                    backup: false
+                    down: false
+                    resolve: true
+                    route: cookie
+                    service: http
+                    slow_start: 0s
+                    drain: false
           - template_file: http/default.conf.j2
             conf_file_name: frontend_default.conf
             conf_file_location: /etc/nginx/conf.d/
@@ -383,5 +418,5 @@
                     port: 9092
                     down: true
                   - address: 0.0.0.0
-                    port: 9083
+                    port: 9093
                     backup: true

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -238,7 +238,6 @@
                 zone:
                   name: frontend_mem_zone
                   size: 64k
-                state: /var/lib/nginx/state/servers.conf
                 least_time:
                   response: last_byte
                   inflight: false
@@ -252,7 +251,8 @@
                 sticky_route:
                   - $cookie_jsessionid
                   - $request_uri
-                servers: []
+                servers:
+                  - address: 0.0.0.0:8081
               - name: backend_servers
                 zone:
                   name: backend_mem_zone

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -1,27 +1,8 @@
 {{ ansible_managed | comment }}
 
 {% if item.upstreams is defined %}
-{% for upstream in item.upstreams %}
-upstream {{ upstream.name }} {
-{% if upstream.lb_method is defined and upstream.lb_method | length %}
-    {{ upstream.lb_method }};
-{% endif %}
-{% if upstream.zone_name is defined and upstream.zone_size is defined %}
-    zone {{ upstream.zone_name }} {{ upstream.zone_size }};
-{% endif %}
-{% for server in upstream.servers %}
-    server {{ server.address }}{{(":" + server.port | string) if server.port is defined}} {% if server.backup is defined and server.backup %}backup{% endif %} {% if server.down is defined and server.down %}down{% else %}weight={{ server.weight | default("1") }} {{ server.health_check | default("") }}{% endif %};
-{% endfor %}
-{% if upstream.sticky_cookie is defined and upstream.sticky_cookie %}
-    sticky cookie srv_id expires=1h  path=/;
-{% endif %}
-{% if upstream.custom_options is defined and upstream.custom_options | length %}
-{% for inline_option in upstream.custom_options %}
-    {{ inline_option }}
-{% endfor %}
-{% endif %}
-}
-{% endfor %}
+{% from 'http/upstream.j2' import upstream with context %}
+{{ upstream(item.upstreams) }}
 {% endif %}
 
 {% if item.proxy_cache is defined %}

--- a/templates/http/upstream.j2
+++ b/templates/http/upstream.j2
@@ -1,0 +1,90 @@
+{{ ansible_managed | comment }}
+{# NGINX Upstream template -- Add directives under its corresponding block #}
+{# Format is as follows #}
+{# Left side (context module_name) -- Right side (module name) #}
+{# HTTP NGINX Upstream -- ngx_http_upstream_module #}
+
+{# HTTP Upstreams -- ngx_http_upstream_module #}
+{% macro upstream(upstreams) %}
+{% for upstream in upstreams %}
+{% if upstream['name'] is defined %}
+upstream {{ upstream['name'] }} {
+{% if upstream['servers'] is defined %}
+{% for server in upstream['servers'] %}
+{% if server['address'] is defined %}
+    server {{ server['address'] -}}
+    {{- (" weight=" + server['weight'] | string) if server['weight'] is defined -}}
+    {{- (" max_conns=" + server['max_conns'] | string) if server['max_conns'] is defined -}}
+    {{- (" max_fails=" + server['max_fails'] | string) if server['max_fails'] is defined -}}
+    {{- (" fail_timeout=" + server['fail_timeout'] | string) if server['fail_timeout'] is defined -}}
+    {{- " backup" if server['backup'] is defined and server['backup'] | bool -}}
+    {{- " down" if server['down'] is defined and server['down'] | bool -}}
+    {{- " resolve" if server['resolve'] is defined and server['resolve'] | bool -}}
+    {{- (" route=" + server['route']) if server['route'] is defined -}}
+    {{- (" service=" + server['service']) if server['service'] is defined -}}
+    {{- (" slow_start=" + server['slow_start'] | string) if server['slow_start'] is defined -}}
+    {{- " drain" if server['drain'] is defined and server['drain'] | bool -}};
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if upstream['zone'] is defined %}
+    zone {{ upstream['zone']['name'] }}{{ (" " + upstream['zone']['size']) if upstream['zone']['size'] is defined }};
+{% endif %}
+{% if upstream['state'] is defined %}
+    state {{ upstream['state'] }};
+{% endif %}
+{% if upstream['hash']['key'] is defined %}
+    hash {{ upstream['hash']['key'] -}}{{ " consistent" if upstream['hash']['consistent'] is defined and upstream['hash']['consistent'] | bool -}};
+{% elif upstream['ip_hash'] is defined and upstream['ip_hash'] | bool %}
+    ip_hash;
+{% elif upstream['least_conn'] is defined and upstream['least_conn'] | bool %}
+    least_conn;
+{% elif upstream['least_time']['response'] is defined  %}
+    least_time {{ upstream['least_time']['response'] -}}{{ " inflight" if upstream['least_time']['inflight'] is defined and upstream['least_time']['inflight'] | bool }};
+{% elif upstream['random'] is defined %}
+    random {{ "two" if upstream['random']['two'] is defined and upstream['random']['two'] | bool }} {{ upstream['random']['method'] if upstream['random']['method'] is defined }};
+{% endif %}
+{% if upstream['queue']['number'] is defined %}
+    queue {{ upstream['queue']['number'] -}}{{ (" timeout=" + upstream['queue']['timeout'] | string) if upstream['queue']['timeout'] is defined }};
+{% endif %}
+{% if upstream['keepalive'] is defined %}
+    keepalive {{ upstream['keepalive'] }};
+{% endif %}
+{% if upstream['keepalive_requests'] is defined %}
+    keepalive_requests {{ upstream['keepalive_requests'] }};
+{% endif %}
+{% if upstream['keepalive_timeout'] is defined %}
+    keepalive_timeout {{ upstream['keepalive_timeout'] }};
+{% endif %}
+{% if upstream['ntlm'] is defined and upstream['ntlm'] | bool %}
+    ntlm;
+{% endif %}
+{% if upstream['resolver']['address'] is defined %}
+    resolver {{ upstream['resolver']['address'] | join(" ") -}}
+    {{- (" valid=" + upstream['resolver']['valid'] | string) if upstream['resolver']['valid'] is defined -}}
+    {{- (" ipv6=" + (upstream['resolver']['ipv6'] | ternary("on", "off"))) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] | bool -}}
+    {{- (" status_zone=" + upstream['resolver']['status_zone']) if upstream['resolver']['status_zone'] is defined -}};
+{% endif %}
+{% if upstream['resolver_timeout'] is defined %}
+    resolver_timeout {{ upstream['resolver_timeout'] }};
+{% endif %}
+{% if upstream['sticky_cookie']['name'] is defined %}
+    sticky cookie {{ upstream['sticky_cookie']['name'] -}}
+    {{- (" expires=" + upstream['sticky_cookie']['expires'] | string) if upstream['sticky_cookie']['expires'] is defined -}}
+    {{- (" domain=" + upstream['sticky_cookie']['domain']) if upstream['sticky_cookie']['domain'] is defined -}}
+    {{- " httponly" if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] | bool -}}
+    {{- (" samesite" + upstream['sticky_cookie']['samesite']) if upstream['sticky_cookie']['samesite'] is defined -}}
+    {{- " secure" if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] | bool -}}
+    {{- (" path=" + upstream['sticky_cookie']['path']) if upstream['sticky_cookie']['path'] is defined -}};
+{% elif upstream['sticky_route'] is defined %}
+    sticky route {{ upstream['sticky_route'] | join(" ") }};
+{% elif upstream['sticky_learn'] is defined %}
+    sticky learn create={{ upstream['sticky_learn']['create'] | join(' create=') }} lookup={{ upstream['sticky_learn']['lookup'] | join(' lookup=') }} zone={{ upstream['sticky_learn']['zone']['name'] + ":" + upstream['sticky_learn']['zone']['size'] | string -}}
+    {{- (" timeout=" + upstream['sticky_learn']['timeout'] | string) if upstream['sticky_learn']['timeout'] is defined -}}
+    {{- " header" if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] | bool -}}
+    {{- " sync" if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] | bool -}};
+{% endif %}
+}
+{% endif %}
+{% endfor %}
+{% endmacro %}

--- a/templates/http/upstream.j2
+++ b/templates/http/upstream.j2
@@ -23,29 +23,29 @@ upstream {{ upstream['name'] }} {
     {{- (" route=" + server['route']) if server['route'] is defined -}}
     {{- (" service=" + server['service']) if server['service'] is defined -}}
     {{- (" slow_start=" + server['slow_start'] | string) if server['slow_start'] is defined -}}
-    {{- " drain" if server['drain'] is defined and server['drain'] | bool -}};
+    {{- " drain" if server['drain'] is defined and server['drain'] | bool }};
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if upstream['zone'] is defined %}
-    zone {{ upstream['zone']['name'] }}{{ (" " + upstream['zone']['size']) if upstream['zone']['size'] is defined }};
+{% if upstream['zone']['name'] is defined %}
+    zone {{ upstream['zone']['name'] }}{{ (" " + upstream['zone']['size'] | string) if upstream['zone']['size'] is defined }};
 {% endif %}
 {% if upstream['state'] is defined %}
     state {{ upstream['state'] }};
 {% endif %}
 {% if upstream['hash']['key'] is defined %}
-    hash {{ upstream['hash']['key'] -}}{{ " consistent" if upstream['hash']['consistent'] is defined and upstream['hash']['consistent'] | bool -}};
+    hash {{ upstream['hash']['key'] }}{{ " consistent" if upstream['hash']['consistent'] is defined and upstream['hash']['consistent'] | bool }};
 {% elif upstream['ip_hash'] is defined and upstream['ip_hash'] | bool %}
     ip_hash;
 {% elif upstream['least_conn'] is defined and upstream['least_conn'] | bool %}
     least_conn;
 {% elif upstream['least_time']['response'] is defined  %}
-    least_time {{ upstream['least_time']['response'] -}}{{ " inflight" if upstream['least_time']['inflight'] is defined and upstream['least_time']['inflight'] | bool }};
+    least_time {{ upstream['least_time']['response'] }}{{ " inflight" if upstream['least_time']['inflight'] is defined and upstream['least_time']['inflight'] | bool }};
 {% elif upstream['random'] is defined %}
-    random {{ "two" if upstream['random']['two'] is defined and upstream['random']['two'] | bool }} {{ upstream['random']['method'] if upstream['random']['method'] is defined }};
+    random{{ " two" if upstream['random']['two'] is defined and upstream['random']['two'] | bool }}{{ (" " + upstream['random']['method']) if upstream['random']['method'] is defined }};
 {% endif %}
 {% if upstream['queue']['number'] is defined %}
-    queue {{ upstream['queue']['number'] -}}{{ (" timeout=" + upstream['queue']['timeout'] | string) if upstream['queue']['timeout'] is defined }};
+    queue {{ upstream['queue']['number'] }}{{ (" timeout=" + upstream['queue']['timeout'] | string) if upstream['queue']['timeout'] is defined }};
 {% endif %}
 {% if upstream['keepalive'] is defined %}
     keepalive {{ upstream['keepalive'] }};
@@ -63,7 +63,7 @@ upstream {{ upstream['name'] }} {
     resolver {{ upstream['resolver']['address'] | join(" ") -}}
     {{- (" valid=" + upstream['resolver']['valid'] | string) if upstream['resolver']['valid'] is defined -}}
     {{- (" ipv6=" + (upstream['resolver']['ipv6'] | ternary("on", "off"))) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] | bool -}}
-    {{- (" status_zone=" + upstream['resolver']['status_zone']) if upstream['resolver']['status_zone'] is defined -}};
+    {{- (" status_zone=" + upstream['resolver']['status_zone']) if upstream['resolver']['status_zone'] is defined }};
 {% endif %}
 {% if upstream['resolver_timeout'] is defined %}
     resolver_timeout {{ upstream['resolver_timeout'] }};
@@ -75,14 +75,14 @@ upstream {{ upstream['name'] }} {
     {{- " httponly" if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] | bool -}}
     {{- (" samesite" + upstream['sticky_cookie']['samesite']) if upstream['sticky_cookie']['samesite'] is defined -}}
     {{- " secure" if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] | bool -}}
-    {{- (" path=" + upstream['sticky_cookie']['path']) if upstream['sticky_cookie']['path'] is defined -}};
+    {{- (" path=" + upstream['sticky_cookie']['path']) if upstream['sticky_cookie']['path'] is defined }};
 {% elif upstream['sticky_route'] is defined %}
     sticky route {{ upstream['sticky_route'] | join(" ") }};
 {% elif upstream['sticky_learn'] is defined %}
     sticky learn create={{ upstream['sticky_learn']['create'] | join(' create=') }} lookup={{ upstream['sticky_learn']['lookup'] | join(' lookup=') }} zone={{ upstream['sticky_learn']['zone']['name'] + ":" + upstream['sticky_learn']['zone']['size'] | string -}}
     {{- (" timeout=" + upstream['sticky_learn']['timeout'] | string) if upstream['sticky_learn']['timeout'] is defined -}}
     {{- " header" if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] | bool -}}
-    {{- " sync" if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] | bool -}};
+    {{- " sync" if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] | bool }};
 {% endif %}
 }
 {% endif %}

--- a/templates/http/upstream.j2
+++ b/templates/http/upstream.j2
@@ -13,39 +13,39 @@ upstream {{ upstream['name'] }} {
 {% for server in upstream['servers'] %}
 {% if server['address'] is defined %}
     server {{ server['address'] -}}
-    {{- (" weight=" + server['weight'] | string) if server['weight'] is defined -}}
-    {{- (" max_conns=" + server['max_conns'] | string) if server['max_conns'] is defined -}}
-    {{- (" max_fails=" + server['max_fails'] | string) if server['max_fails'] is defined -}}
-    {{- (" fail_timeout=" + server['fail_timeout'] | string) if server['fail_timeout'] is defined -}}
-    {{- " backup" if server['backup'] is defined and server['backup'] | bool -}}
-    {{- " down" if server['down'] is defined and server['down'] | bool -}}
-    {{- " resolve" if server['resolve'] is defined and server['resolve'] | bool -}}
-    {{- (" route=" + server['route']) if server['route'] is defined -}}
-    {{- (" service=" + server['service']) if server['service'] is defined -}}
-    {{- (" slow_start=" + server['slow_start'] | string) if server['slow_start'] is defined -}}
-    {{- " drain" if server['drain'] is defined and server['drain'] | bool }};
+    {{- (' weight=' + server['weight'] | string) if server['weight'] is defined -}}
+    {{- (' max_conns=' + server['max_conns'] | string) if server['max_conns'] is defined -}}
+    {{- (' max_fails=' + server['max_fails'] | string) if server['max_fails'] is defined -}}
+    {{- (' fail_timeout=' + server['fail_timeout'] | string) if server['fail_timeout'] is defined -}}
+    {{- ' backup' if server['backup'] is defined and server['backup'] | bool -}}
+    {{- ' down' if server['down'] is defined and server['down'] | bool -}}
+    {{- ' resolve' if server['resolve'] is defined and server['resolve'] | bool -}}
+    {{- (' route=' + server['route']) if server['route'] is defined -}}
+    {{- (' service=' + server['service']) if server['service'] is defined -}}
+    {{- (' slow_start=' + server['slow_start'] | string) if server['slow_start'] is defined -}}
+    {{- ' drain' if server['drain'] is defined and server['drain'] | bool }};
 {% endif %}
 {% endfor %}
 {% endif %}
 {% if upstream['zone']['name'] is defined %}
-    zone {{ upstream['zone']['name'] }}{{ (" " + upstream['zone']['size'] | string) if upstream['zone']['size'] is defined }};
+    zone {{ upstream['zone']['name'] }}{{ (' ' + upstream['zone']['size'] | string) if upstream['zone']['size'] is defined }};
 {% endif %}
 {% if upstream['state'] is defined %}
     state {{ upstream['state'] }};
 {% endif %}
 {% if upstream['hash']['key'] is defined %}
-    hash {{ upstream['hash']['key'] }}{{ " consistent" if upstream['hash']['consistent'] is defined and upstream['hash']['consistent'] | bool }};
+    hash {{ upstream['hash']['key'] }}{{ ' consistent' if upstream['hash']['consistent'] is defined and upstream['hash']['consistent'] | bool }};
 {% elif upstream['ip_hash'] is defined and upstream['ip_hash'] | bool %}
     ip_hash;
 {% elif upstream['least_conn'] is defined and upstream['least_conn'] | bool %}
     least_conn;
 {% elif upstream['least_time']['response'] is defined  %}
-    least_time {{ upstream['least_time']['response'] }}{{ " inflight" if upstream['least_time']['inflight'] is defined and upstream['least_time']['inflight'] | bool }};
+    least_time {{ upstream['least_time']['response'] }}{{ ' inflight' if upstream['least_time']['inflight'] is defined and upstream['least_time']['inflight'] | bool }};
 {% elif upstream['random'] is defined %}
-    random{{ " two" if upstream['random']['two'] is defined and upstream['random']['two'] | bool }}{{ (" " + upstream['random']['method']) if upstream['random']['method'] is defined }};
+    random{{ ' two' if upstream['random']['two'] is defined and upstream['random']['two'] | bool }}{{ (' ' + upstream['random']['method']) if upstream['random']['method'] is defined }};
 {% endif %}
 {% if upstream['queue']['number'] is defined %}
-    queue {{ upstream['queue']['number'] }}{{ (" timeout=" + upstream['queue']['timeout'] | string) if upstream['queue']['timeout'] is defined }};
+    queue {{ upstream['queue']['number'] }}{{ (' timeout=' + upstream['queue']['timeout'] | string) if upstream['queue']['timeout'] is defined }};
 {% endif %}
 {% if upstream['keepalive'] is defined %}
     keepalive {{ upstream['keepalive'] }};
@@ -60,29 +60,29 @@ upstream {{ upstream['name'] }} {
     ntlm;
 {% endif %}
 {% if upstream['resolver']['address'] is defined %}
-    resolver {{ upstream['resolver']['address'] | join(" ") -}}
-    {{- (" valid=" + upstream['resolver']['valid'] | string) if upstream['resolver']['valid'] is defined -}}
-    {{- (" ipv6=" + (upstream['resolver']['ipv6'] | ternary("on", "off"))) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] | bool -}}
-    {{- (" status_zone=" + upstream['resolver']['status_zone']) if upstream['resolver']['status_zone'] is defined }};
+    resolver {{ upstream['resolver']['address'] | join(' ') -}}
+    {{- (' valid=' + upstream['resolver']['valid'] | string) if upstream['resolver']['valid'] is defined -}}
+    {{- (' ipv6=' + (upstream['resolver']['ipv6'] | ternary('on', 'off'))) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] | bool -}}
+    {{- (' status_zone=' + upstream['resolver']['status_zone']) if upstream['resolver']['status_zone'] is defined }};
 {% endif %}
 {% if upstream['resolver_timeout'] is defined %}
     resolver_timeout {{ upstream['resolver_timeout'] }};
 {% endif %}
 {% if upstream['sticky_cookie']['name'] is defined %}
     sticky cookie {{ upstream['sticky_cookie']['name'] -}}
-    {{- (" expires=" + upstream['sticky_cookie']['expires'] | string) if upstream['sticky_cookie']['expires'] is defined -}}
-    {{- (" domain=" + upstream['sticky_cookie']['domain']) if upstream['sticky_cookie']['domain'] is defined -}}
-    {{- " httponly" if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] | bool -}}
-    {{- (" samesite" + upstream['sticky_cookie']['samesite']) if upstream['sticky_cookie']['samesite'] is defined -}}
-    {{- " secure" if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] | bool -}}
-    {{- (" path=" + upstream['sticky_cookie']['path']) if upstream['sticky_cookie']['path'] is defined }};
+    {{- (' expires=' + upstream['sticky_cookie']['expires'] | string) if upstream['sticky_cookie']['expires'] is defined -}}
+    {{- (' domain=' + upstream['sticky_cookie']['domain']) if upstream['sticky_cookie']['domain'] is defined -}}
+    {{- ' httponly' if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] | bool -}}
+    {{- (' samesite' + upstream['sticky_cookie']['samesite']) if upstream['sticky_cookie']['samesite'] is defined -}}
+    {{- ' secure' if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] | bool -}}
+    {{- (' path=' + upstream['sticky_cookie']['path']) if upstream['sticky_cookie']['path'] is defined }};
 {% elif upstream['sticky_route'] is defined %}
-    sticky route {{ upstream['sticky_route'] | join(" ") }};
+    sticky route {{ upstream['sticky_route'] | join(' ') }};
 {% elif upstream['sticky_learn'] is defined %}
-    sticky learn create={{ upstream['sticky_learn']['create'] | join(' create=') }} lookup={{ upstream['sticky_learn']['lookup'] | join(' lookup=') }} zone={{ upstream['sticky_learn']['zone']['name'] + ":" + upstream['sticky_learn']['zone']['size'] | string -}}
-    {{- (" timeout=" + upstream['sticky_learn']['timeout'] | string) if upstream['sticky_learn']['timeout'] is defined -}}
-    {{- " header" if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] | bool -}}
-    {{- " sync" if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] | bool }};
+    sticky learn create={{ upstream['sticky_learn']['create'] | join(' create=') }} lookup={{ upstream['sticky_learn']['lookup'] | join(' lookup=') }} zone={{ upstream['sticky_learn']['zone']['name'] + ':' + upstream['sticky_learn']['zone']['size'] | string -}}
+    {{- (' timeout=' + upstream['sticky_learn']['timeout'] | string) if upstream['sticky_learn']['timeout'] is defined -}}
+    {{- ' header' if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] | bool -}}
+    {{- ' sync' if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] | bool }};
 {% endif %}
 }
 {% endif %}


### PR DESCRIPTION
### Proposed changes
Refactor the `upstream` HTTP config template into its own separate file. The following variables have changed (check `defaults/main/template.yml` for example values):
*   `port` is no longer supported. Instead, include the port as part of your `address`.
*   `lb_method` is no longer supported. Instead, you will have to specifically set the method you want to use.
*   `zone_name` and `zone_size` have been modified into a dictionary.
*   `sticky_cookie` is no longer supported as is. You will now have to configure the `sticky_cookie` values.
*   The `health_check` parameter within the `server` dictionary is no longer supported. Instead, manually set `max_fails` and `fail_timeout`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [ ] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
