### PR TITLE
Refactor HTTP Proxy module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,27 @@ BREAKING CHANGES:
     *   Rename the `nginx_config_html_upload_*` parameters to `nginx_config_upload_html_*`.
     *   Rename the `nginx_config_ssl_upload_*` parameters to `nginx_config_upload_ssl_*`.
 *   Tweak the `nginx_config_html_upload` and `nginx_config_ssl_upload` parameters to ow use a list instead of a single `src` and `dest` value (check `defaults/main/upload.yml` for an example).
-*   Refactor the config templates to simplify the creation of templates as well as development and maintenance moving forward:
+*   Refactor the base config templates to simplify the creation of templates as well as development and maintenance moving forward:
     *   Modify `servers`, `servers.listen`, `server.locations`, `upstream` and `upstream.servers` from nested dictionaries in the `http` and `stream` configuration templates to lists, as well as modify the `nginx_config_html_demo_template` variable from a nested dictionary to a list. To update your templates, replace the aforementioned nested dictionary keys by lists (place a dash in front of the topmost nested value within each aforementioned nested dictionary).
     *   Remove/merge the `web_server` and `reverse_proxy` nested dictionary keys from the HTTP templates. These often lead to confusing and unnecessary code duplication and hard to maintain code. To update your templates, remove both keys and adjust your spacing accordingly.
-*   Refactor the `upstream` HTTP config template into its own separate file. The following variables have changed (check `defaults/main/template.yml` for example values):
+*   Refactor the `upstream` HTTP config template into its own separate file. The following variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
     *   `port` is no longer supported. Instead, include the port as part of your `address`.
     *   `lb_method` is no longer supported. Instead, you will have to specifically set the method you want to use.
     *   `zone_name` and `zone_size` have been modified into a dictionary.
     *   `sticky_cookie` is no longer supported as is. You will now have to configure the `sticky_cookie` values.
     *   The `health_check` parameter within the `server` dictionary is no longer supported. Instead, manually set `max_fails` and `fail_timeout`.
+*   Refactor the `proxy` HTTP config template into its own separate file. All variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
+    *   All `proxy_*` related variables now live under the `proxy` dictionary key, with the exception of `proxy_pass` and `proxy_cache_path`. You can specify the `proxy` dictionary key inside the `http`, `server`, and `location` contexts.
+    *   Remove the `nginx_config_main_template.http_settings.cache` dictionary variable. Use `nginx_config_http_template.*.proxy_cache_path` instead.
+    *   Remove the `location.websocket` variable. Use `location.proxy.set_header` instead:
+    ```yaml
+    proxy:
+      set_header:
+        - field: Upgrade
+          value: $http_upgrade
+        - field: Connection
+          value: Upgrade
+    ```
 *   Rename some NGINX template config parameters to align with NGINX directive names:
     *   Rename `proxy_hide_headers` to `proxy_hide_header`.
     *   Rename `html_file_location` to `root`.

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -18,7 +18,7 @@ nginx_config_main_template:
   #   - modules/ngx_http_js_module.so
   user: nginx
   worker_processes: auto
-  # worker_rlimit_nofile: 1024
+  worker_rlimit_nofile: 1024
   pid: /var/run/nginx.pid
   error_log:
     location: /var/log/nginx/error.log
@@ -39,21 +39,21 @@ nginx_config_main_template:
       request_buffer_overflow_action: pass  # Optional -- 'pass' or 'drop'
       user_defined_signatures: []  # Optional list
     app_protect:  # Optional -- Configure NGINX App Protect
-      enable: false  # Optional
+      enable: false  # Optional boolean
       policy_file: path  # Optional
-      security_log_enable: false  # Optional
+      security_log_enable: false  # Optional boolean
       security_log:  # Optional
         path: path  # Required
         destination: dest  # Required
     grpc_global:  # Optional -- Configure GRPC
       bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
         address: $remote_addr  # Required
-        transparent: true  # Optional
+        transparent: true  # Optional boolean
       buffer_size: 4k  # Optional
       connect_timeout: 60s  # Optional
       hide_header: []  # Optional list
       ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
-      intercept_errors: false  # Optional
+      intercept_errors: false  # Optional boolean
       next_upstream: []  # Optional list
       next_upstream_timeout: 0  # Optional
       next_upstream_tries: 0  # Optional
@@ -63,22 +63,22 @@ nginx_config_main_template:
       set_header:  # Optional
         - field: Accept-Encoding  # Required
           value: '""'  # Required
-      socket_keepalive: false  # Optional
-      ssl_certificate: fileLocation  # Optional
-      ssl_certificate_key: fileLocation  # Optional
+      socket_keepalive: false  # Optional boolean
+      ssl_certificate: /path/to/file  # Optional
+      ssl_certificate_key: /path/to/file  # Optional
       ssl_ciphers: DEFAULT  # Optional
-      ssl_conf_command: command  # Optional
-      ssl_crl: fileLocation  # Optional
+      ssl_conf_command: 'command'  # Optional
+      ssl_crl: /path/to/file  # Optional
       ssl_name: serverName  # Optional
-      ssl_password_file: fileLocation  # Optional
+      ssl_password_file: /path/to/file  # Optional
       ssl_protocols: []  # Optional list
-      ssl_server_name: false  # Optional
-      ssl_session_reuse: true  # Optional
-      ssl_trusted_certificate: fileLocation  # Optional
-      ssl_verify: false  # Optional
+      ssl_server_name: false  # Optional boolean
+      ssl_session_reuse: true  # Optional boolean
+      ssl_trusted_certificate: /path/to/file  # Optional
+      ssl_verify: false  # Optional boolean
       ssl_verify_depth: 1  # Optional
     gzip:  # Optional -- Configure GZIP
-      enable: true  # Optional
+      enable: true  # Optional boolean
       buffers:  # Optional
         number: 32  # Required
         size: 4k  # Required
@@ -88,7 +88,146 @@ nginx_config_main_template:
       min_length: 20  # Optional
       proxied: []  # Optional list
       types: []  # Optional list
-      vary: false  # Optional
+      vary: false  # Optional boolean
+    proxy_cache_path:  # Optional -- Configure Proxy Cache Path
+      - path: /var/cache/nginx/proxy  # Required
+        levels: "1:1"  # Optional
+        use_temp_path: false  # Optional boolean
+        inactive: 10m  # Optional
+        keys_zone:  # Required
+          name: proxy_cache  # Required
+          size: 10m  # Required
+        max_size: 2g  # Optional
+        min_free: 1g  # Optional
+        manager_files: 100  # Optional
+        manager_sleep: 500ms  # Optional
+        manager_threshold: 200ms  # Optional
+        loader_files: 100  # Optional
+        loader_sleep: 50ms  # Optional
+        loader_threshold: 200ms  # Optional
+        purger: false  # Optional boolean -- NGINX Plus
+        purger_files: 10  # Optional -- NGINX Plus
+        purger_sleep: 50ms  # Optional -- NGINX Plus
+        purger_threshold: 50ms  # Optional -- NGINX Plus
+    proxy:  # Optional -- Configure Proxy
+      bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_bind
+        address: 0.0.0.0  # Required
+        transparent: false  # Optional boolean
+      buffer_size: 4k  # Optional
+      buffering: true  # Optional boolean
+      buffers:  # Optional
+        number: 8  # Required
+        size: 4k  # Required
+      busy_buffers_size: 8k  # Optional
+      cache: false  # Optional -- Set to 'false' or specify cache zone
+      cache_background_update: false  # Optional boolean
+      cache_bypass: $cookie_seed  # Optional nested list, list, or single value
+        # - - $cookie_nocache
+        #   - $arg_nocache$arg_comment
+        # - $cookie_path
+      cache_convert_head: true  # Optional boolean
+      cache_key: $scheme$proxy_host$request_uri  # Optional
+      cache_lock: false  # Optional boolean
+      cache_lock_age: 5s  # Optional
+      cache_lock_timeout: 5s  # Optional
+      cache_max_range_offset: 1  # Optional
+      cache_methods: []  # Optional list
+        # - GET
+        # - HEAD
+      cache_min_uses: 1  # Optional
+      cache_purge: sample  # Optional list or string
+        # - cache_key
+        # - cache_purge
+      cache_revalidate: false  # Optional boolean
+      cache_use_stale: false  # Optional list
+        # - error
+        # - timeout
+      cache_valid:  # Optional list of codes
+        - code: 200  # Optional list or string
+          # - 201
+          # - 202
+          time: 10m  # Required
+      connect_timeout: 60s  # Optional
+      cookie_domain: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_domain
+        # - domain: localhost  # Required
+        #   replacement: example.org  # Required
+      cookie_flags: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_flags
+        # cookie: one  # Required
+        # flag: []  # Optional list
+        #   - httponly
+      cookie_path: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_path
+        # - path: $uri  # Required
+        #   replacement: $someuri  # Required
+      force_ranges: false  # Optional boolean
+      headers_hash_bucket_size: 64  # Optional
+      headers_hash_max_size: 512  # Optional
+      hide_header: Date  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      http_version: 1.1  # Optional
+      ignore_client_abort: false  # Optional boolean
+      ignore_headers: X-Accel-Redirect  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      intercept_errors: false  # Optional boolean
+      limit_rate: 0  # Optional
+      max_temp_file_size: 1024m  # Optional
+      method: GET  # Optional
+      next_upstream: false  # Optional -- Set to 'false' to disable proxy_next_upstream or include a variables list or string
+        # - error
+        # - timeout
+      next_upstream_timeout: 0  # Optional
+      next_upstream_tries: 0  # Optional
+      no_cache: $cookie_nocache  # Optional list or string
+        # - $cookie_nocache
+        # - $arg_nocache$arg_comment
+      pass_header: Date  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      pass_request_body: false  # Optional boolean
+      pass_request_headers: true  # Optional boolean
+      read_timeout: 60s  # Optional
+      redirect: false  # Optional -- Set to 'false' to disable proxy_redirect
+        # - original: http://upstream:port/two/
+        #   replacement: /one/
+        # - default
+      request_buffering: false  # Optional boolean
+      send_lowat: 0  # Optional
+      send_timeout: 60s  # Optional
+      set_body: body  # Optional
+      set_header: []  # Optional list
+        # - field: Host
+        #   value: $proxy_host
+        # - field: Connection
+        #   value: close
+      socket_keepalive: false  # Optional boolean
+      ssl_certificate: /path/to/file  # Optional
+      ssl_certificate_key: /path/to/file  # Optional
+      ssl_ciphers: DEFAULT  # Optional list or string
+        # - DEFAULT
+      ssl_conf_command: 'command'  # Optional list or string
+        # - 'command'
+      ssl_crl: /path/to/file  # Optional
+      ssl_name: $proxy_host  # Optional
+      ssl_password_file: /path/to/file  # Optional
+      ssl_protocols: TLSv1  # Optional list or string
+        # - TLSv1
+        # - TLSv1.1
+        # - TLSv1.2
+      ssl_server_name: false  # Optional boolean
+      ssl_session_reuse: true  # Optional boolean
+      ssl_trusted_certificate: /path/to/file  # Optional
+      ssl_verify: false  # Optional boolean
+      ssl_verify_depth: 1  # Optional
+      store: false  # Optional boolean
+      store_access:  # Optional
+        user: rw  # Optional
+        group: rw  # Optional
+        all: r  # Optional
+      temp_file_write_size: 8k  # Optional
+      temp_path:  # Optional
+        path: /var/cache/nginx/proxy/temp  # Required
+        level: 2  # Optional -- One of '1', '2' or '3'
     access_log_format:
       - name: main
         format: |-
@@ -105,7 +244,7 @@ nginx_config_main_template:
     cache: false
     rate_limit: false
     keyval: false
-    # server_tokens: "off"
+    server_tokens: "off"
   http_global_autoindex: false
   sub_filter:
     # sub_filters: []
@@ -163,17 +302,17 @@ nginx_config_http_template:
             - field: Accept-Encoding  # Required
               value: '""'  # Required
           socket_keepalive: false  # Optional
-          ssl_certificate: fileLocation  # Optional
-          ssl_certificate_key: fileLocation  # Optional
+          ssl_certificate: /path/to/file  # Optional
+          ssl_certificate_key: /path/to/file  # Optional
           ssl_ciphers: DEFAULT  # Optional
-          ssl_conf_command: command  # Optional
-          ssl_crl: fileLocation  # Optional
-          ssl_name: serverName  # Optional
-          ssl_password_file: fileLocation  # Optional
+          ssl_conf_command: 'command'  # Optional
+          ssl_crl: /path/to/file  # Optional
+          ssl_name: $host  # Optional
+          ssl_password_file: /path/to/file  # Optional
           ssl_protocols: []  # Optional list
           ssl_server_name: false  # Optional
           ssl_session_reuse: true  # Optional
-          ssl_trusted_certificate: fileLocation  # Optional
+          ssl_trusted_certificate: /path/to/file  # Optional
           ssl_verify: false  # Optional
           ssl_verify_depth: 1  # Optional
         gzip:  # Optional -- Configure GZIP
@@ -188,6 +327,125 @@ nginx_config_http_template:
           proxied: []  # Optional list
           types: []  # Optional list
           vary: false  # Optional
+        proxy:  # Optional -- Configure Proxy
+          bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_bind
+            address: 0.0.0.0  # Required
+            transparent: false  # Optional boolean
+          buffer_size: 4k  # Optional
+          buffering: true  # Optional boolean
+          buffers:  # Optional
+            number: 8  # Required
+            size: 4k  # Required
+          busy_buffers_size: 8k  # Optional
+          cache: false  # Optional -- Set to 'false' or specify cache zone
+          cache_background_update: false  # Optional boolean
+          cache_bypass: $cookie_seed  # Optional nested list, list, or single value
+            # - - $cookie_nocache
+            #   - $arg_nocache$arg_comment
+            # - $cookie_path
+          cache_convert_head: true  # Optional boolean
+          cache_key: $scheme$proxy_host$request_uri  # Optional
+          cache_lock: false  # Optional boolean
+          cache_lock_age: 5s  # Optional
+          cache_lock_timeout: 5s  # Optional
+          cache_max_range_offset: 1  # Optional
+          cache_methods: []  # Optional list
+            # - GET
+            # - HEAD
+          cache_min_uses: 1  # Optional
+          cache_purge: sample  # Optional list or string
+            # - cache_key
+            # - cache_purge
+          cache_revalidate: false  # Optional boolean
+          cache_use_stale: false  # Optional list
+            # - error
+            # - timeout
+          cache_valid:  # Optional list of codes
+            - code: 200  # Optional list or string
+              # - 201
+              # - 202
+              time: 10m  # Required
+          connect_timeout: 60s  # Optional
+          cookie_domain: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_domain
+            # - domain: localhost  # Required
+            #   replacement: example.org  # Required
+          cookie_flags: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_flags
+            # cookie: one  # Required
+            # flag: []  # Optional list
+            #   - httponly
+          cookie_path: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_path
+            # - path: $uri  # Required
+            #   replacement: $someuri  # Required
+          force_ranges: false  # Optional boolean
+          headers_hash_bucket_size: 64  # Optional
+          headers_hash_max_size: 512  # Optional
+          hide_header: Date  # Optional list or string
+            # - Date
+            # - X-Accel-Redirect
+          http_version: 1.1  # Optional
+          ignore_client_abort: false  # Optional boolean
+          ignore_headers: X-Accel-Redirect  # Optional list or string
+            # - Date
+            # - X-Accel-Redirect
+          intercept_errors: false  # Optional boolean
+          limit_rate: 0  # Optional
+          max_temp_file_size: 1024m  # Optional
+          method: GET  # Optional
+          next_upstream: false  # Optional -- Set to 'false' to disable proxy_next_upstream or include a variables list or string
+            # - error
+            # - timeout
+          next_upstream_timeout: 0  # Optional
+          next_upstream_tries: 0  # Optional
+          no_cache: $cookie_nocache  # Optional list or string
+            # - $cookie_nocache
+            # - $arg_nocache$arg_comment
+          pass_header: Date  # Optional list or string
+            # - Date
+            # - X-Accel-Redirect
+          pass_request_body: false  # Optional boolean
+          pass_request_headers: true  # Optional boolean
+          read_timeout: 60s  # Optional
+          redirect: false  # Optional -- Set to 'false' to disable proxy_redirect
+            # - original: http://upstream:port/two/
+            #   replacement: /one/
+            # - default
+          request_buffering: false  # Optional boolean
+          send_lowat: 0  # Optional
+          send_timeout: 60s  # Optional
+          set_body: body  # Optional
+          set_header: []  # Optional list
+            # - field: Host
+            #   value: $proxy_host
+            # - field: Connection
+            #   value: close
+          socket_keepalive: false  # Optional boolean
+          ssl_certificate: /path/to/file  # Optional
+          ssl_certificate_key: /path/to/file  # Optional
+          ssl_ciphers: DEFAULT  # Optional list or string
+            # - DEFAULT
+          ssl_conf_command: 'command'  # Optional list or string
+            # - 'command'
+          ssl_crl: /path/to/file  # Optional
+          ssl_name: $proxy_host  # Optional
+          ssl_password_file: /path/to/file  # Optional
+          ssl_protocols: TLSv1  # Optional list or string
+            # - TLSv1
+            # - TLSv1.1
+            # - TLSv1.2
+          ssl_server_name: false  # Optional boolean
+          ssl_session_reuse: true  # Optional boolean
+          ssl_trusted_certificate: /path/to/file  # Optional
+          ssl_verify: false  # Optional boolean
+          ssl_verify_depth: 1  # Optional
+          store: false  # Optional boolean
+          store_access:  # Optional
+            user: rw  # Optional
+            group: rw  # Optional
+            all: r  # Optional
+          temp_file_write_size: 8k  # Optional
+          temp_path:  # Optional
+            path: /var/cache/nginx/proxy/temp  # Required
+            level: 2  # Optional -- One of '1', '2' or '3'
         ssl:
           cert: /etc/ssl/certs/default.crt
           key: /etc/ssl/private/default.key
@@ -226,7 +484,6 @@ nginx_config_http_template:
         #   name: $auth_user
         #   value: $upstream_http_x_user
         client_max_body_size: 1m
-        proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
         add_headers:
           strict_transport_security:
             name: Strict-Transport-Security
@@ -236,7 +493,6 @@ nginx_config_http_template:
           #   name: Header-X
           #   value: Value-X
           #   always: false
-
         sub_filter:
           # sub_filters: []
           last_modified: false
@@ -300,8 +556,127 @@ nginx_config_http_template:
               proxied: []  # Optional list
               types: []  # Optional list
               vary: false  # Optional
+            proxy_pass: localhost:9000  # Optional -- Configure Proxy Pass
+            proxy:  # Optional -- Configure Proxy
+              bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_bind
+                address: 0.0.0.0  # Required
+                transparent: false  # Optional boolean
+              buffer_size: 4k  # Optional
+              buffering: true  # Optional boolean
+              buffers:  # Optional
+                number: 8  # Required
+                size: 4k  # Required
+              busy_buffers_size: 8k  # Optional
+              cache: false  # Optional -- Set to 'false' or specify cache zone
+              cache_background_update: false  # Optional boolean
+              cache_bypass: $cookie_seed  # Optional nested list, list, or single value
+                # - - $cookie_nocache
+                #   - $arg_nocache$arg_comment
+                # - $cookie_path
+              cache_convert_head: true  # Optional boolean
+              cache_key: $scheme$proxy_host$request_uri  # Optional
+              cache_lock: false  # Optional boolean
+              cache_lock_age: 5s  # Optional
+              cache_lock_timeout: 5s  # Optional
+              cache_max_range_offset: 1  # Optional
+              cache_methods: []  # Optional list
+                # - GET
+                # - HEAD
+              cache_min_uses: 1  # Optional
+              cache_purge: sample  # Optional list or string
+                # - cache_key
+                # - cache_purge
+              cache_revalidate: false  # Optional boolean
+              cache_use_stale: false  # Optional list
+                # - error
+                # - timeout
+              cache_valid:  # Optional list of codes
+                - code: 200  # Optional list or string
+                  # - 201
+                  # - 202
+                  time: 10m  # Required
+              connect_timeout: 60s  # Optional
+              cookie_domain: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_domain
+                # - domain: localhost  # Required
+                #   replacement: example.org  # Required
+              cookie_flags: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_flags
+                # cookie: one  # Required
+                # flag: []  # Optional list
+                #   - httponly
+              cookie_path: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_path
+                # - path: $uri  # Required
+                #   replacement: $someuri  # Required
+              force_ranges: false  # Optional boolean
+              headers_hash_bucket_size: 64  # Optional
+              headers_hash_max_size: 512  # Optional
+              hide_header: Date  # Optional list or string
+                # - Date
+                # - X-Accel-Redirect
+              http_version: 1.1  # Optional
+              ignore_client_abort: false  # Optional boolean
+              ignore_headers: X-Accel-Redirect  # Optional list or string
+                # - Date
+                # - X-Accel-Redirect
+              intercept_errors: false  # Optional boolean
+              limit_rate: 0  # Optional
+              max_temp_file_size: 1024m  # Optional
+              method: GET  # Optional
+              next_upstream: false  # Optional -- Set to 'false' to disable proxy_next_upstream or include a variables list or string
+                # - error
+                # - timeout
+              next_upstream_timeout: 0  # Optional
+              next_upstream_tries: 0  # Optional
+              no_cache: $cookie_nocache  # Optional list or string
+                # - $cookie_nocache
+                # - $arg_nocache$arg_comment
+              pass_header: Date  # Optional list or string
+                # - Date
+                # - X-Accel-Redirect
+              pass_request_body: false  # Optional boolean
+              pass_request_headers: true  # Optional boolean
+              read_timeout: 60s  # Optional
+              redirect: false  # Optional -- Set to 'false' to disable proxy_redirect
+                # - original: http://upstream:port/two/
+                #   replacement: /one/
+                # - default
+              request_buffering: false  # Optional boolean
+              send_lowat: 0  # Optional
+              send_timeout: 60s  # Optional
+              set_body: body  # Optional
+              set_header: []  # Optional list
+                # - field: Host
+                #   value: $proxy_host
+                # - field: Connection
+                #   value: close
+              socket_keepalive: false  # Optional boolean
+              ssl_certificate: /path/to/file  # Optional
+              ssl_certificate_key: /path/to/file  # Optional
+              ssl_ciphers: DEFAULT  # Optional list or string
+                # - DEFAULT
+              ssl_conf_command: 'command'  # Optional list or string
+                # - 'command'
+              ssl_crl: /path/to/file  # Optional
+              ssl_name: $proxy_host  # Optional
+              ssl_password_file: /path/to/file  # Optional
+              ssl_protocols: TLSv1  # Optional list or string
+                # - TLSv1
+                # - TLSv1.1
+                # - TLSv1.2
+              ssl_server_name: false  # Optional boolean
+              ssl_session_reuse: true  # Optional boolean
+              ssl_trusted_certificate: /path/to/file  # Optional
+              ssl_verify: false  # Optional boolean
+              ssl_verify_depth: 1  # Optional
+              store: false  # Optional boolean
+              store_access:  # Optional
+                user: rw  # Optional
+                group: rw  # Optional
+                all: r  # Optional
+              temp_file_write_size: 8k  # Optional
+              temp_path:  # Optional
+                path: /var/cache/nginx/proxy/temp  # Required
+                level: 2  # Optional -- One of '1', '2' or '3'
             include_files: []
-            proxy_hide_header: []  # A list of headers which shouldn't be passed to the application
             add_headers:
               strict_transport_security:
                 name: Strict-Transport-Security
@@ -331,8 +706,6 @@ nginx_config_http_template:
             #     code: 302
             #     url: https://sso.somehost.local/?url=https://$http_host$request_uri
             # custom_options: []
-            proxy_connect_timeout: null
-            proxy_pass: http://backend
             # rewrites:
             #   - /foo(.*) /$1 break
             # proxy_pass_request_body: off
@@ -340,46 +713,7 @@ nginx_config_http_template:
             #   - 192.168.1.0/24
             # denies:
             #   - all
-            proxy_set_header:
-              header_host:
-                name: Host
-                value: $host
             internal: false
-            proxy_store: off
-            proxy_store_acccess: user:rw
-            proxy_read_timeout: null
-            proxy_send_timeout: null
-            proxy_ssl:
-              cert: /etc/ssl/certs/proxy_default.crt
-              key: /etc/ssl/private/proxy_default.key
-              trusted_cert: /etc/ssl/certs/proxy_ca.crt
-              protocols: TLSv1 TLSv1.1 TLSv1.2
-              ciphers: HIGH:!aNULL:!MD5
-              verify: false
-              verify_depth: 1
-              session_reuse: true
-            proxy_cache: backend_proxy_cache
-            proxy_cache_valid:
-              - code: 200
-                time: 10m
-              - code: 301
-                time: 1m
-            proxy_temp_path:
-              path: /var/cache/nginx/proxy/backend/temp
-            proxy_cache_lock: false
-            proxy_cache_min_uses: 3
-            proxy_cache_revalidate: false
-            proxy_cache_use_stale:
-              - http_403
-              - http_404
-            proxy_ignore_headers:
-              - Vary
-              - Cache-Control
-            proxy_cookie_path:
-              path: /web/
-              replacement: /
-            proxy_buffering: false
-            proxy_http_version: 1.0
             websocket: false
             sub_filter:
               # sub_filters: []
@@ -392,31 +726,145 @@ nginx_config_http_template:
             location: /
             code: 301
             value: http://$host$request_uri
-    proxy_cache:
-      proxy_cache_path:
-        - path: /var/cache/nginx/proxy/backend
-          keys_zone:
-            name: backend_proxy_cache
-            size: 10m
-          levels: "1:2"
-          max_size: 10g
-          inactive: 60m
-          use_temp_path: true
-      proxy_temp_path:
-        path: /var/cache/nginx/proxy/temp
-      proxy_cache_valid:
-        - code: 200
-          time: 10m
-        - code: 301
-          time: 1m
-      proxy_cache_lock: true
-      proxy_cache_min_uses: 5
-      proxy_cache_revalidate: true
-      proxy_cache_use_stale:
-        - error
-        - timeout
-      proxy_ignore_headers:
-        - Expires
+    proxy_cache_path:  # Optional -- Configure Proxy Cache Path
+      - path: /var/cache/nginx/proxy/backend  # Required
+        levels: "1:1"  # Optional
+        use_temp_path: false  # Optional boolean
+        inactive: 10m  # Optional
+        keys_zone:  # Required
+          name: backend_proxy_cache  # Required
+          size: 10m  # Required
+        max_size: 2g  # Optional
+        min_free: 1g  # Optional
+        manager_files: 100  # Optional
+        manager_sleep: 500ms  # Optional
+        manager_threshold: 200ms  # Optional
+        loader_files: 100  # Optional
+        loader_sleep: 50ms  # Optional
+        loader_threshold: 200ms  # Optional
+        purger: false  # Optional boolean
+        purger_files: 10  # Optional
+        purger_sleep: 50ms  # Optional
+        purger_threshold: 50ms  # Optional
+    proxy:  # Optional -- Configure Proxy
+      bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_bind
+        address: 0.0.0.0  # Required
+        transparent: false  # Optional boolean
+      buffer_size: 4k  # Optional
+      buffering: true  # Optional boolean
+      buffers:  # Optional
+        number: 8  # Required
+        size: 4k  # Required
+      busy_buffers_size: 8k  # Optional
+      cache: false  # Optional -- Set to 'false' or specify cache zone
+      cache_background_update: false  # Optional boolean
+      cache_bypass: $cookie_seed  # Optional nested list, list, or single value
+        # - - $cookie_nocache
+        #   - $arg_nocache$arg_comment
+        # - $cookie_path
+      cache_convert_head: true  # Optional boolean
+      cache_key: $scheme$proxy_host$request_uri  # Optional
+      cache_lock: false  # Optional boolean
+      cache_lock_age: 5s  # Optional
+      cache_lock_timeout: 5s  # Optional
+      cache_max_range_offset: 1  # Optional
+      cache_methods: []  # Optional list
+        # - GET
+        # - HEAD
+      cache_min_uses: 1  # Optional
+      cache_purge: sample  # Optional list or string
+        # - cache_key
+        # - cache_purge
+      cache_revalidate: false  # Optional boolean
+      cache_use_stale: false  # Optional list
+        # - error
+        # - timeout
+      cache_valid:  # Optional list of codes
+        - code: 200  # Optional list or string
+          # - 201
+          # - 202
+          time: 10m  # Required
+      connect_timeout: 60s  # Optional
+      cookie_domain: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_domain
+        # - domain: localhost  # Required
+        #   replacement: example.org  # Required
+      cookie_flags: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_flags
+        # cookie: one  # Required
+        # flag: []  # Optional list
+        #   - httponly
+      cookie_path: false  # Optional -- Set to 'false' and remove/comment nested variables to disable proxy_cookie_path
+        # - path: $uri  # Required
+        #   replacement: $someuri  # Required
+      force_ranges: false  # Optional boolean
+      headers_hash_bucket_size: 64  # Optional
+      headers_hash_max_size: 512  # Optional
+      hide_header: Date  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      http_version: 1.1  # Optional
+      ignore_client_abort: false  # Optional boolean
+      ignore_headers: X-Accel-Redirect  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      intercept_errors: false  # Optional boolean
+      limit_rate: 0  # Optional
+      max_temp_file_size: 1024m  # Optional
+      method: GET  # Optional
+      next_upstream: false  # Optional -- Set to 'false' to disable proxy_next_upstream or include a variables list or string
+        # - error
+        # - timeout
+      next_upstream_timeout: 0  # Optional
+      next_upstream_tries: 0  # Optional
+      no_cache: $cookie_nocache  # Optional list or string
+        # - $cookie_nocache
+        # - $arg_nocache$arg_comment
+      pass_header: Date  # Optional list or string
+        # - Date
+        # - X-Accel-Redirect
+      pass_request_body: false  # Optional boolean
+      pass_request_headers: true  # Optional boolean
+      read_timeout: 60s  # Optional
+      redirect: false  # Optional -- Set to 'false' to disable proxy_redirect
+        # - original: http://upstream:port/two/
+        #   replacement: /one/
+        # - default
+      request_buffering: false  # Optional boolean
+      send_lowat: 0  # Optional
+      send_timeout: 60s  # Optional
+      set_body: body  # Optional
+      set_header: []  # Optional list
+        # - field: Host
+        #   value: $proxy_host
+        # - field: Connection
+        #   value: close
+      socket_keepalive: false  # Optional boolean
+      ssl_certificate: /path/to/file  # Optional
+      ssl_certificate_key: /path/to/file  # Optional
+      ssl_ciphers: DEFAULT  # Optional list or string
+        # - DEFAULT
+      ssl_conf_command: 'command'  # Optional list or string
+        # - 'command'
+      ssl_crl: /path/to/file  # Optional
+      ssl_name: $proxy_host  # Optional
+      ssl_password_file: /path/to/file  # Optional
+      ssl_protocols: TLSv1  # Optional list or string
+        # - TLSv1
+        # - TLSv1.1
+        # - TLSv1.2
+      ssl_server_name: false  # Optional boolean
+      ssl_session_reuse: true  # Optional boolean
+      ssl_trusted_certificate: /path/to/file  # Optional
+      ssl_verify: false  # Optional boolean
+      ssl_verify_depth: 1  # Optional
+      store: false  # Optional boolean
+      store_access:  # Optional
+        user: rw  # Optional
+        group: rw  # Optional
+        all: r  # Optional
+      temp_file_write_size: 8k  # Optional
+      temp_path:  # Optional
+        path: /var/cache/nginx/proxy/temp  # Required
+        level: 2  # Optional -- One of '1', '2' or '3'
     upstreams:  # Optional -- Configure NGINX Upstreams
       - name: backend  # Required
         servers:  # Optional -- Cannot be used if 'state' directive is defined

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,6 +12,14 @@
         nginx_config_selinux_tcp_ports:
           - 80
 
+        nginx_config_upload_ssl_enable: true
+        nginx_config_upload_ssl_crt:
+          - src: ../common/files/ssl/molecule.crt
+            dest: /etc/ssl/certs
+        nginx_config_upload_ssl_key:
+          - src: ../common/files/ssl/molecule.key
+            dest: /etc/ssl/private
+
         nginx_config_main_template_enable: true
         nginx_config_main_template:
           template_file: nginx.conf.j2
@@ -134,8 +142,6 @@
                   - name: main
                     location: /var/log/nginx/access.log
                 client_max_body_size: 512k
-                proxy_hide_header:
-                  - X-Powered-By
                 add_headers:
                   strict_transport_security:
                     name: Strict-Transport-Security
@@ -148,8 +154,6 @@
                   - location: /
                     grpc:
                       pass: localhost:9000
-                    proxy_hide_header:
-                      - X-Powered-By
                     add_headers:
                       strict_transport_security:
                         name: Strict-Transport-Security
@@ -162,112 +166,167 @@
                     rewrites:
                       - (.*).html(.*) $1$2
                     proxy_pass: http://frontend_servers/
-                    proxy_cache: frontend_proxy_cache
-                    proxy_cache_valid:
-                      - code: 200
-                        time: 10m
-                      - code: 301
-                        time: 1m
-                    proxy_temp_path:
-                      path: /var/cache/nginx/proxy/frontend/temp
-                    proxy_cache_lock: false
-                    proxy_cache_min_uses: 3
-                    proxy_cache_revalidate: false
-                    proxy_cache_use_stale:
-                      - http_403
-                      - http_404
-                    proxy_ignore_headers:
-                      - Vary
-                      - Cache-Control
-                    proxy_redirect: false
-                    proxy_set_header:
-                      header_host:
-                        name: Host
-                        value: $host
-                      header_x_real_ip:
-                        name: X-Real-IP
-                        value: $remote_addr
-                      header_x_forwarded_for:
-                        name: X-Forwarded-For
-                        value: $proxy_add_x_forwarded_for
-                      header_x_forwarded_proto:
-                        name: X-Forwarded-Proto
-                        value: $scheme
-                    proxy_buffering: false
+                    proxy:
+                      bind: false
+                      buffer_size: 4k
+                      buffering: true
+                      buffers:
+                        number: 8
+                        size: 4k
+                      busy_buffers_size: 8k
+                      cache: false
+                      cache_background_update: false
+                      cache_bypass:
+                        - - $cookie_nocache
+                          - $arg_nocache$arg_comment
+                        - $cookie_test
+                      cache_convert_head: true
+                      cache_key: $scheme$proxy_host$request_uri
+                      cache_lock: false
+                      cache_lock_age: 5s
+                      cache_lock_timeout: 5s
+                      cache_max_range_offset: 1
+                      cache_methods:
+                        - GET
+                        - HEAD
+                      cache_min_uses: 1
+                      cache_revalidate: false
+                      cache_use_stale: false
+                      cache_valid:
+                        - code: 200
+                          time: 10m
+                        - code:
+                            - 201
+                            - 202
+                          time: 10m
+                        - time: 1m
+                      connect_timeout: 60s
+                      cookie_domain:
+                        - domain: localhost
+                          replacement: example.com
+                      cookie_flags: false
+                      cookie_path: false
+                      force_ranges: false
+                      headers_hash_bucket_size: 64
+                      headers_hash_max_size: 512
+                      hide_header:
+                        - Date
+                        - X-Accel-Redirect
+                      http_version: 1.1
+                      ignore_client_abort: false
+                      ignore_headers:
+                        - X-Accel-Redirect
+                      intercept_errors: false
+                      limit_rate: 0
+                      max_temp_file_size: 1024m
+                      method: GET
+                      next_upstream:
+                        - error
+                        - timeout
+                      next_upstream_timeout: 0
+                      next_upstream_tries: 0
+                      no_cache:
+                        - $cookie_nocache
+                        - $arg_nocache$arg_comment
+                      pass_header:
+                        - Date
+                        - X-Accel-Redirect
+                      pass_request_body: false
+                      pass_request_headers: true
+                      read_timeout: 60s
+                      redirect: false
+                      request_buffering: false
+                      # send_lowat: 0  # not supported on linux
+                      send_timeout: 60s
+                      set_body: body
+                      set_header:
+                        - field: Host
+                          value: $proxy_host
+                        - field: Connection
+                          value: close
+                      socket_keepalive: false
+                      ssl_certificate: /etc/ssl/certs/molecule.crt
+                      ssl_certificate_key: /etc/ssl/private/molecule.key
+                      ssl_ciphers:
+                        - DEFAULT
+                      ssl_conf_command: Options PrioritizeChaCha?
+                      # ssl_crl: /path/to/file
+                      ssl_name: $proxy_host
+                      # ssl_password_file: /path/to/file
+                      ssl_protocols:
+                        - TLSv1
+                        - TLSv1.1
+                        - TLSv1.2
+                        - TLSv1.3
+                      ssl_server_name: false
+                      ssl_session_reuse: true
+                      # ssl_trusted_certificate: /path/to/file
+                      ssl_verify: false
+                      ssl_verify_depth: 1
+                      store: false
+                      store_access:
+                        user: rw
+                        group: rw
+                        all: r
+                      temp_file_write_size: 8k
+                      temp_path:
+                        path: /var/cache/nginx/proxy
+                        level: 2
                     client_max_body_size: 5m
                     sub_filter:
                       last_modified: false
                       once: true
                   - location: /backend
                     proxy_pass: http://backend_servers/
-                    proxy_cache: backend_proxy_cache
-                    proxy_cache_valid:
-                      - time: 10m
-                    proxy_temp_path:
-                      path: /var/cache/nginx/proxy/backend/temp
-                    proxy_cache_lock: true
-                    proxy_cache_min_uses: 2
-                    proxy_cache_revalidate: true
-                    proxy_cache_use_stale:
-                      - http_500
-                      - http_502
-                      - http_503
-                    proxy_redirect: default
-                    proxy_set_header:
-                      header_host:
-                        name: Host
-                        value: $host
-                      header_x_real_ip:
-                        name: X-Real-IP
-                        value: $remote_addr
-                      header_x_forwarded_for:
-                        name: X-Forwarded-For
-                        value: $proxy_add_x_forwarded_for
-                      header_x_forwarded_proto:
-                        name: X-Forwarded-Proto
-                        value: $scheme
-                    proxy_cookie_path:
-                      path: /web/
-                      replacement: /
+                    proxy:
+                      set_header:
+                        - field: Host
+                          value: $host
+                        - field: X-Real-IP
+                          value: $remote_addr
+                        - field: X-Forwarded-For
+                          value: $proxy_add_x_forwarded_for
+                        - field: X-Forwarded-Proto
+                          value: $scheme
                 returns:
                   return301:
                     location: ^~ /old-path
                     code: 301
                     value: http://$host/new-path
-            proxy_cache:
-              proxy_cache_path:
-                - path: /var/cache/nginx/proxy/frontend
-                  keys_zone:
-                    name: frontend_proxy_cache
-                    size: 5m
-                  levels: "1:2"
-                  max_size: 5g
-                  inactive: 30m
-                  use_temp_path: true
-                - path: /var/cache/nginx/proxy/backend
-                  keys_zone:
-                    name: backend_proxy_cache
-                    size: 10m
-                  levels: "1:2"
-                  max_size: 10g
-                  inactive: 60m
-                  use_temp_path: true
-              proxy_temp_path:
-                path: /var/cache/nginx/proxy/temp
-              proxy_cache_lock: true
-              proxy_cache_min_uses: 5
-              proxy_cache_revalidate: true
-              proxy_cache_use_stale:
-                - error
-                - timeout
-              proxy_ignore_headers:
-                - Expires
+            proxy_cache_path:
+              - path: /var/cache/nginx/proxy/frontend
+                levels: "1:1"
+                use_temp_path: false
+                inactive: 10m
+                keys_zone:
+                  name: frontend_proxy_cache
+                  size: 10m
+                max_size: 2g
+                min_free: 1g
+                manager_files: 100
+                manager_sleep: 500ms
+                manager_threshold: 200ms
+                loader_files: 100
+                loader_sleep: 50ms
+                loader_threshold: 200ms
+                # purger: false  # NGINX Plus only
+                # purger_files: 10
+                # purger_sleep: 50ms
+                # purger_threshold: 50ms
+              - path: /var/cache/nginx/proxy/backend
+                levels: "1:2"
+                use_temp_path: true
+                keys_zone:
+                  name: backend_proxy_cache
+                  size: 10m
+                inactive: 60m
+                max_size: 10g
             upstreams:
               - name: frontend_servers
-                least_conn: true
                 zone:
                   name: frontend_mem_zone
                   size: 64k
+                least_conn: true
                 keepalive: 32
                 keepalive_requests: 100
                 keepalive_timeout: 60s
@@ -277,10 +336,10 @@
                     max_fails: 3
                     fail_timeout: 5s
               - name: backend_servers
-                least_conn: true
                 zone:
                   name: backend_mem_zone
                   size: 64k
+                least_conn: true
                 servers:
                   - address: 0.0.0.0:8082
                     weight: 1
@@ -319,10 +378,9 @@
                     - "'proxied_for_ip' '$http_x_forwarded_for'"
                   last_modified: false
                   once: false
+                  types: "text/html"
                 locations:
                   - location: /
-                    proxy_hide_header:
-                      - X-Powered-By
                     root: /usr/share/nginx/html
                     index: frontend_index.html
                     autoindex: false

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -8,6 +8,14 @@
       vars:
         nginx_config_debug_output: true
 
+        nginx_config_upload_ssl_enable: true
+        nginx_config_upload_ssl_crt:
+          - src: ../common/files/ssl/molecule.crt
+            dest: /etc/ssl/certs
+        nginx_config_upload_ssl_key:
+          - src: ../common/files/ssl/molecule.key
+            dest: /etc/ssl/private
+
         nginx_config_main_template_enable: true
         nginx_config_main_template:
           template_file: nginx.conf.j2
@@ -34,6 +42,44 @@
               failure_mode_action: pass
               cookie_seed: testseed
               compressed_requests_action: drop
+            grpc_global:
+              bind:
+                address: $remote_addr
+                transparent: false
+              buffer_size: 4k
+              connect_timeout: 60s
+              hide_header:
+                - X-Accel-Redirect
+              ignore_headers:
+                - X-Accel-Redirect
+              intercept_errors: false
+              next_upstream:
+                - timeout
+              next_upstream_timeout: 0
+              next_upstream_tries: 0
+              pass_header:
+                - X-Accel-Charset
+              read_timeout: 60s
+              send_timeout: 60s
+              set_header:
+                - field: Accept-Encoding
+                  value: '""'
+              socket_keepalive: false
+            gzip:
+              enable: true
+              buffers:
+                number: 32
+                size: 4k
+              comp_level: 1
+              disable:
+                - '"msie6"'
+              http_version: 1.1
+              min_length: 20
+              proxied:
+                - expired
+              types:
+                - text/html
+              vary: false
             default_type: application/octet-stream
             access_log_format:
               - name: main
@@ -66,7 +112,7 @@
         nginx_config_rest_api_enable: true
         nginx_config_rest_api_write: false
         nginx_config_rest_api_access_log: false
-        nginx_config_rest_api_dashboard: false
+        nginx_config_rest_api_dashboard: true
 
         nginx_config_http_template_enable: true
         nginx_config_http_template:
@@ -121,6 +167,8 @@
                       policy_file: /etc/nginx/app-protect-security-policy.json
                     proxy_hide_header:
                       - X-Powered-By
+                    grpc:
+                      pass: localhost:9000
                     add_headers:
                       strict_transport_security:
                         name: Strict-Transport-Security
@@ -133,106 +181,161 @@
                     rewrites:
                       - (.*).html(.*) $1$2
                     proxy_pass: http://frontend_servers/
-                    proxy_cache: frontend_proxy_cache
-                    proxy_cache_valid:
-                      - code: 200
-                        time: 10m
-                      - code: 301
-                        time: 1m
-                    proxy_temp_path:
-                      path: /var/cache/nginx/proxy/frontend/temp
-                    proxy_cache_lock: false
-                    proxy_cache_min_uses: 3
-                    proxy_cache_revalidate: false
-                    proxy_cache_use_stale:
-                      - http_403
-                      - http_404
-                    proxy_ignore_headers:
-                      - Vary
-                      - Cache-Control
-                    proxy_redirect: false
-                    proxy_set_header:
-                      header_host:
-                        name: Host
-                        value: $host
-                      header_x_real_ip:
-                        name: X-Real-IP
-                        value: $remote_addr
-                      header_x_forwarded_for:
-                        name: X-Forwarded-For
-                        value: $proxy_add_x_forwarded_for
-                      header_x_forwarded_proto:
-                        name: X-Forwarded-Proto
-                        value: $scheme
-                    proxy_buffering: false
+                    proxy:
+                      bind: false
+                      buffer_size: 4k
+                      buffering: true
+                      buffers:
+                        number: 8
+                        size: 4k
+                      busy_buffers_size: 8k
+                      cache: false
+                      cache_background_update: false
+                      cache_bypass:
+                        - - $cookie_nocache
+                          - $arg_nocache$arg_comment
+                        - $cookie_test
+                      cache_convert_head: true
+                      cache_key: $scheme$proxy_host$request_uri
+                      cache_lock: false
+                      cache_lock_age: 5s
+                      cache_lock_timeout: 5s
+                      cache_max_range_offset: 1
+                      cache_methods:
+                        - GET
+                        - HEAD
+                      cache_min_uses: 1
+                      cache_revalidate: false
+                      cache_use_stale: false
+                      cache_valid:
+                        - code: 200
+                          time: 10m
+                        - code:
+                            - 201
+                            - 202
+                          time: 10m
+                        - time: 1m
+                      connect_timeout: 60s
+                      cookie_domain:
+                        - domain: localhost
+                          replacement: example.com
+                      cookie_flags: false
+                      cookie_path: false
+                      force_ranges: false
+                      headers_hash_bucket_size: 64
+                      headers_hash_max_size: 512
+                      hide_header:
+                        - Date
+                        - X-Accel-Redirect
+                      http_version: 1.1
+                      ignore_client_abort: false
+                      ignore_headers:
+                        - X-Accel-Redirect
+                      intercept_errors: false
+                      limit_rate: 0
+                      max_temp_file_size: 1024m
+                      method: GET
+                      next_upstream:
+                        - error
+                        - timeout
+                      next_upstream_timeout: 0
+                      next_upstream_tries: 0
+                      no_cache:
+                        - $cookie_nocache
+                        - $arg_nocache$arg_comment
+                      pass_header:
+                        - Date
+                        - X-Accel-Redirect
+                      pass_request_body: false
+                      pass_request_headers: true
+                      read_timeout: 60s
+                      redirect: false
+                      request_buffering: false
+                      # send_lowat: 0  # not supported on linux
+                      send_timeout: 60s
+                      set_body: body
+                      set_header:
+                        - field: Host
+                          value: $proxy_host
+                        - field: Connection
+                          value: close
+                      socket_keepalive: false
+                      ssl_certificate: /etc/ssl/certs/molecule.crt
+                      ssl_certificate_key: /etc/ssl/private/molecule.key
+                      ssl_ciphers:
+                        - DEFAULT
+                      ssl_conf_command: Options PrioritizeChaCha?
+                      # ssl_crl: /path/to/file
+                      ssl_name: $proxy_host
+                      # ssl_password_file: /path/to/file
+                      ssl_protocols:
+                        - TLSv1
+                        - TLSv1.1
+                        - TLSv1.2
+                        - TLSv1.3
+                      ssl_server_name: false
+                      ssl_session_reuse: true
+                      # ssl_trusted_certificate: /path/to/file
+                      ssl_verify: false
+                      ssl_verify_depth: 1
+                      store: false
+                      store_access:
+                        user: rw
+                        group: rw
+                        all: r
+                      temp_file_write_size: 8k
+                      temp_path:
+                        path: /var/cache/nginx/proxy
+                        level: 2
                     client_max_body_size: 5m
                     sub_filter:
                       last_modified: false
                       once: true
                   - location: /backend
                     proxy_pass: http://backend_servers/
-                    proxy_cache: backend_proxy_cache
-                    proxy_cache_valid:
-                      - time: 10m
-                    proxy_temp_path:
-                      path: /var/cache/nginx/proxy/backend/temp
-                    proxy_cache_lock: true
-                    proxy_cache_min_uses: 2
-                    proxy_cache_revalidate: true
-                    proxy_cache_use_stale:
-                      - http_500
-                      - http_502
-                      - http_503
-                    proxy_redirect: default
-                    proxy_set_header:
-                      header_host:
-                        name: Host
-                        value: $host
-                      header_x_real_ip:
-                        name: X-Real-IP
-                        value: $remote_addr
-                      header_x_forwarded_for:
-                        name: X-Forwarded-For
-                        value: $proxy_add_x_forwarded_for
-                      header_x_forwarded_proto:
-                        name: X-Forwarded-Proto
-                        value: $scheme
-                    proxy_cookie_path:
-                      path: /web/
-                      replacement: /
+                    proxy:
+                      set_header:
+                        - field: Host
+                          value: $host
+                        - field: X-Real-IP
+                          value: $remote_addr
+                        - field: X-Forwarded-For
+                          value: $proxy_add_x_forwarded_for
+                        - field: X-Forwarded-Proto
+                          value: $scheme
                 returns:
                   return301:
                     location: ^~ /old-path
                     code: 301
                     value: http://$host/new-path
-            proxy_cache:
-              proxy_cache_path:
-                - path: /var/cache/nginx/proxy/frontend
-                  keys_zone:
-                    name: frontend_proxy_cache
-                    size: 5m
-                  levels: "1:2"
-                  max_size: 5g
-                  inactive: 30m
-                  use_temp_path: true
-                - path: /var/cache/nginx/proxy/backend
-                  keys_zone:
-                    name: backend_proxy_cache
-                    size: 10m
-                  levels: "1:2"
-                  max_size: 10g
-                  inactive: 60m
-                  use_temp_path: true
-              proxy_temp_path:
-                path: /var/cache/nginx/proxy/temp
-              proxy_cache_lock: true
-              proxy_cache_min_uses: 5
-              proxy_cache_revalidate: true
-              proxy_cache_use_stale:
-                - error
-                - timeout
-              proxy_ignore_headers:
-                - Expires
+            proxy_cache_path:
+              - path: /var/cache/nginx/proxy/frontend
+                levels: "1:1"
+                use_temp_path: false
+                inactive: 10m
+                keys_zone:
+                  name: frontend_proxy_cache
+                  size: 10m
+                max_size: 2g
+                min_free: 1g
+                manager_files: 100
+                manager_sleep: 500ms
+                manager_threshold: 200ms
+                loader_files: 100
+                loader_sleep: 50ms
+                loader_threshold: 200ms
+                purger: false
+                purger_files: 10
+                purger_sleep: 50ms
+                purger_threshold: 50ms
+              - path: /var/cache/nginx/proxy/backend
+                levels: "1:2"
+                use_temp_path: true
+                keys_zone:
+                  name: backend_proxy_cache
+                  size: 10m
+                inactive: 60m
+                max_size: 10g
             upstreams:
               - name: frontend_servers
                 zone:
@@ -326,8 +429,6 @@
                   types: "text/html"
                 locations:
                   - location: /
-                    proxy_hide_header:
-                      - X-Powered-By
                     root: /usr/share/nginx/html
                     index: frontend_index.html
                     autoindex: false

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -43,14 +43,6 @@
   when: nginx_config_main_template_enable | bool
   notify: (Handler - NGINX Config) Run NGINX
 
-- name: Ensure NGINX HTTP directory exists
-  file:
-    path: "{{ item.conf_file_location | default('/etc/nginx/conf.d/') }}"
-    state: directory
-    mode: 0755
-  loop: "{{ nginx_config_http_template }}"
-  when: nginx_config_http_template_enable | bool
-
 - name: Ensure NGINX proxy cache directories exist
   file:
     path: "{{ item.1.path }}"
@@ -59,8 +51,16 @@
     mode: 0755
   with_subelements:
     - "{{ nginx_config_http_template }}"
-    - proxy_cache.proxy_cache_path
+    - proxy_cache_path
     - skip_missing: true
+  when: nginx_config_main_template_enable | bool
+
+- name: Ensure NGINX HTTP directory exists
+  file:
+    path: "{{ item.conf_file_location | default('/etc/nginx/conf.d/') }}"
+    state: directory
+    mode: 0755
+  loop: "{{ nginx_config_http_template }}"
   when: nginx_config_http_template_enable | bool
 
 - name: Dynamically generate NGINX HTTP config files

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -4,46 +4,15 @@
 {% from 'http/upstream.j2' import upstream with context %}
 {{ upstream(item.upstreams) }}
 {% endif %}
+{% if item.proxy_cache_path is defined %}
+{% from 'http/proxy.j2' import proxy_cache_path with context %}
+{{ proxy_cache_path(item.proxy_cache_path) }}
+{% endif %}
+{% if item.proxy is defined %}
+{% from 'http/proxy.j2' import proxy with context %}
+{{ proxy(item.proxy) }}
+{% endif %}
 
-{% if item.proxy_cache is defined %}
-{% if item.proxy_cache.proxy_cache_path is defined %}
-{% for proxy_cache_path in item.proxy_cache.proxy_cache_path %}
-proxy_cache_path {{ proxy_cache_path.path }} keys_zone={{ proxy_cache_path.keys_zone.name }}:{{ proxy_cache_path.keys_zone.size }}
-                levels={{ proxy_cache_path.levels }} max_size={{ proxy_cache_path.max_size }}
-                inactive={{ proxy_cache_path.inactive }} use_temp_path={{ proxy_cache_path.use_temp_path | ternary("on", "off") }};
-{% endfor %}
-{% if item.proxy_cache.proxy_cache_background_update is defined and item.proxy_cache.proxy_cache_background_update %}
-proxy_cache_background_update {{ item.proxy_cache.proxy_cache_background_update | ternary("on", "off") }};
-{% endif %}
-{% if item.proxy_cache.proxy_cache_lock is defined and item.proxy_cache.proxy_cache_lock %}
-proxy_cache_lock {{ item.proxy_cache.proxy_cache_lock | ternary("on", "off") }};
-{% endif %}
-{% if item.proxy_cache.proxy_cache_min_uses is defined %}
-proxy_cache_min_uses {{ item.proxy_cache.proxy_cache_min_uses }};
-{% endif %}
-{% if item.proxy_cache.proxy_cache_revalidate is defined and item.proxy_cache.proxy_cache_revalidate %}
-proxy_cache_revalidate {{ item.proxy_cache.proxy_cache_revalidate | ternary("on", "off") }};
-{% endif %}
-{% if item.proxy_cache.proxy_cache_use_stale is defined %}
-proxy_cache_use_stale {{ item.proxy_cache.proxy_cache_use_stale | join(" ") }};
-{% endif %}
-{% if item.proxy_cache.proxy_ignore_headers is defined %}
-proxy_ignore_headers {{ item.proxy_cache.proxy_ignore_headers | join(" ") }};
-{% endif %}
-{% if item.proxy_cache.proxy_temp_path is defined %}
-proxy_temp_path {{ item.proxy_cache.proxy_temp_path.path }} {{ item.proxy_cache.proxy_temp_path.level_1 | default("") }} {{ item.proxy_cache.proxy_temp_path.level_2 | default("") }} {{ item.proxy_cache.proxy_temp_path.level_3 | default("") }};
-{% endif %}
-{% if item.proxy_cache.proxy_cache_valid is defined %}
-{% for proxy_cache_valid in item.proxy_cache.proxy_cache_valid %}
-{% if proxy_cache_valid.code is defined %}
-proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
-{% elif proxy_cache_valid.time is defined and proxy_cache_valid.code is not defined %}
-proxy_cache_valid {{ proxy_cache_valid.time }};
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endif %}
-{% endif %}
 {% if item.auth_request_http is defined %}
 auth_request {{ item.auth_request_http }};
 {% endif %}
@@ -80,6 +49,12 @@ server {
 {% from 'http/gzip.j2' import gzip with context %}
 {% filter indent(4) %}
     {{ gzip(server.gzip) }}
+{% endfilter %}
+{% endif %}
+{% if server.proxy is defined %}
+{% from 'http/proxy.j2' import proxy with context %}
+{% filter indent(4) %}
+    {{ proxy(server.proxy) }}
 {% endfilter %}
 {% endif %}
 {% if server.ssl is defined %}
@@ -125,11 +100,6 @@ server {
 {% if server.include_files is defined and server.include_files | length %}
 {% for file in server.include_files %}
     include "{{ file }}";
-{% endfor %}
-{% endif %}
-{% if server.proxy_hide_header is defined %}
-{% for header in server.proxy_hide_header %}
-    proxy_hide_header {{ header }};
 {% endfor %}
 {% endif %}
 {% if server.add_headers is defined %}
@@ -216,6 +186,18 @@ server {
         {{ gzip(location.gzip) }}
 {% endfilter %}
 {% endif %}
+{% if location.proxy is defined %}
+{% from 'http/proxy.j2' import proxy with context %}
+{% filter indent(8) %}
+        {{ proxy(location.proxy) }}
+{% endfilter %}
+{% endif %}
+{% if location.proxy_pass is defined %}
+{% from 'http/proxy.j2' import proxy_pass with context %}
+{% filter indent(8) %}
+        {{ proxy_pass(location.proxy_pass) }}
+{% endfilter %}
+{% endif %}
 {% if location.root is defined %}
         root   {{ location.root }};
 {% endif %}
@@ -228,11 +210,6 @@ server {
 {% if location.include_files is defined and location.include_files | length %}
 {% for file in location.include_files %}
         include "{{ file }}";
-{% endfor %}
-{% endif %}
-{% if location.proxy_hide_header is defined %}
-{% for header in location.proxy_hide_header %}
-        proxy_hide_header {{ header }};
 {% endfor %}
 {% endif %}
 {% if location.add_headers is defined %}
@@ -261,31 +238,10 @@ server {
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if location.proxy_connect_timeout is defined %}
-        proxy_connect_timeout {{ location.proxy_connect_timeout }};
-{% endif %}
-{% if location.proxy_pass is defined %}
-        proxy_pass {{ location.proxy_pass }};
-{% endif %}
 {% if location.rewrites is defined %}
 {% for rewrite in location.rewrites %}
         rewrite {{ rewrite }};
 {% endfor %}
-{% endif %}
-{% if location.proxy_read_timeout is defined %}
-        proxy_read_timeout {{ location.proxy_read_timeout }};
-{% endif %}
-{% if location.proxy_send_timeout is defined %}
-        proxy_send_timeout {{ location.proxy_send_timeout }};
-{% endif %}
-{% if location.proxy_pass_request_body is defined %}
-        proxy_pass_request_body {{ location.proxy_pass_request_body }};
-{% endif %}
-{% if location.proxy_store is defined %}
-        proxy_store {{ location.proxy_store | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_store_access is defined %}
-        proxy_store_access {{ location.proxy_store_access }};
 {% endif %}
 {% if location.allows is defined %}
 {% for allow in location.allows %}
@@ -297,98 +253,11 @@ server {
         deny {{ deny }};
 {% endfor %}
 {% endif %}
-{% if location.proxy_set_header is defined %}
-{% for header in location.proxy_set_header %}
-        proxy_set_header {{ location.proxy_set_header[header].name }} {{ location.proxy_set_header[header].value }};
-{% endfor %}
-{% endif %}
-{% if location.proxy_http_version is defined %}
-        proxy_http_version {{ location.proxy_http_version }};
-{% endif %}
-{% if location.websocket is defined %}
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-{% endif %}
 {% if location.try_files is defined %}
         try_files {{ location.try_files }};
 {% endif %}
-
-{% if location.proxy_ssl is defined %}
-{% if location.proxy_ssl.cert is defined %}
-        proxy_ssl_certificate {{ location.proxy_ssl.cert }};
-{% endif %}
-{% if location.proxy_ssl.key is defined %}
-        proxy_ssl_certificate_key {{ location.proxy_ssl.key }};
-{% endif %}
-{% if location.proxy_ssl.trusted_cert is defined %}
-        proxy_ssl_trusted_certificate {{ location.proxy_ssl.trusted_cert }};
-{% endif %}
-{% if location.proxy_ssl.server_name is defined %}
-        proxy_ssl_server_name {{ location.proxy_ssl.server_name | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_ssl.name is defined %}
-        proxy_ssl_name {{ location.proxy_ssl.name }};
-{% endif %}
-{% if location.proxy_ssl.protocols is defined %}
-        proxy_ssl_protocols {{ location.proxy_ssl.protocols }};
-{% endif %}
-{% if location.proxy_ssl.ciphers is defined %}
-        proxy_ssl_ciphers {{ location.proxy_ssl.ciphers }};
-{% endif %}
-{% if location.proxy_ssl.verify is defined %}
-        proxy_ssl_verify {{ location.proxy_ssl.verify | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_ssl.verify_depth is defined %}
-        proxy_ssl_verify_depth {{ location.proxy_ssl.verify_depth }};
-{% endif %}
-{% if location.proxy_ssl.session_reuse is defined %}
-        proxy_ssl_session_reuse {{ location.proxy_ssl.session_reuse | ternary("on", "off") }};
-{% endif %}
-{% endif %}
-{% if location.proxy_redirect is defined %}
-        proxy_redirect {{ location.proxy_redirect | ternary(location.proxy_redirect, "off") }};
-{% endif %}
-{% if location.proxy_cache is defined %}
-        proxy_cache {{ location.proxy_cache }};
-{% endif %}
-{% if location.proxy_cache_valid is defined %}
-{% for proxy_cache_valid in location.proxy_cache_valid %}
-{% if proxy_cache_valid.code is defined %}
-        proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
-{% elif proxy_cache_valid.time is defined and proxy_cache_valid.code is not defined %}
-        proxy_cache_valid {{ proxy_cache_valid.time }};
-{% endif %}
-{% endfor %}
-{% endif %}
-{% if location.proxy_cache_background_update is defined %}
-        proxy_cache_background_update {{ location.proxy_cache_background_update | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_cache_lock is defined %}
-        proxy_cache_lock {{ location.proxy_cache_lock | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_cache_min_uses is defined %}
-        proxy_cache_min_uses {{ location.proxy_cache_min_uses }};
-{% endif %}
-{% if location.proxy_cache_revalidate is defined %}
-        proxy_cache_revalidate {{ location.proxy_cache_revalidate | ternary("on", "off") }};
-{% endif %}
-{% if location.proxy_cache_use_stale is defined %}
-        proxy_cache_use_stale {{ location.proxy_cache_use_stale | join(" ") }};
-{% endif %}
-{% if location.proxy_temp_path is defined %}
-        proxy_temp_path {{ location.proxy_temp_path.path }} {{ location.proxy_temp_path.level_1 | default("") }} {{ location.proxy_temp_path.level_2 | default("") }} {{ location.proxy_temp_path.level_3 | default("") }};
-{% endif %}
-{% if location.proxy_ignore_headers is defined %}
-        proxy_ignore_headers {{ location.proxy_ignore_headers | join(" ") }};
-{% endif %}
 {% if location.client_max_body_size is defined %}
         client_max_body_size {{ location.client_max_body_size }};
-{% endif %}
-{% if location.proxy_cookie_path is defined %}
-        proxy_cookie_path {{ location.proxy_cookie_path.path }} {{ location.proxy_cookie_path.replacement }};
-{% endif %}
-{% if location.proxy_buffering is defined %}
-        proxy_buffering {{ location.proxy_buffering | ternary("on", "off") }};
 {% endif %}
 {% if location.sub_filter.sub_filters is defined and location.sub_filter.sub_filters | length %}
 {% for sub_filter in location.sub_filter.sub_filters %}

--- a/templates/http/proxy.j2
+++ b/templates/http/proxy.j2
@@ -1,0 +1,282 @@
+{{ ansible_managed | comment }}
+{# NGINX Proxy template -- Add directives under its corresponding block #}
+{# Format is as follows #}
+{# Left side (context module_name) -- Right side (module name) #}
+{# HTTP NGINX Proxy -- ngx_http_proxy_module #}
+
+{% macro proxy_cache_path(proxy_cache_path) %}
+{% for proxy in proxy_cache_path %}
+proxy_cache_path {{ proxy['path'] -}}
+{{- (' levels=' + proxy['levels']) if proxy['levels'] is defined -}}
+{{- (' use_temp_path=' + (proxy['use_temp_path'] | ternary('on', 'off'))) if proxy['use_temp_path'] is defined and proxy['use_temp_path'] is boolean -}}
+{{- (' keys_zone=' + proxy['keys_zone']['name'] + ':' + (proxy['keys_zone']['size'] | string)) if proxy['keys_zone'] is defined -}}
+{{- (' inactive=' + proxy['inactive'] | string) if proxy['inactive'] is defined -}}
+{{- (' max_size=' + proxy['max_size'] | string) if proxy['max_size'] is defined -}}
+{{- (' min_free=' + proxy['min_free'] | string) if proxy['min_free'] is defined -}}
+{{- (' manager_files=' + proxy['manager_files'] | string) if proxy['manager_files'] is defined -}}
+{{- (' manager_sleep=' + proxy['manager_sleep'] | string) if proxy['manager_sleep'] is defined -}}
+{{- (' manager_threshold=' + proxy['manager_threshold'] | string) if proxy['manager_threshold'] is defined -}}
+{{- (' loader_files=' + proxy['loader_files'] | string) if proxy['loader_files'] is defined -}}
+{{- (' loader_sleep=' + proxy['loader_sleep'] | string) if proxy['loader_sleep'] is defined -}}
+{{- (' loader_threshold=' + proxy['loader_threshold'] | string) if proxy['loader_threshold'] is defined -}}
+{{- (' purger=' + (proxy['purger'] | ternary('on', 'off'))) if proxy['purger'] is defined and proxy['cache_path']['purger'] is boolean -}}
+{{- (' purger_files=' + proxy['purger_files'] | string) if proxy['purger_files'] is defined -}}
+{{- (' purger_sleep=' + proxy['purger_sleep'] | string) if proxy['purger_sleep'] is defined -}}
+{{- (' purger_threshold=' + proxy['purger_threshold'] | string) if proxy['purger_threshold'] is defined }};
+{% endfor %}
+{% endmacro %}
+
+{% macro proxy(proxy) %}
+{% if proxy['bind'] is defined %}
+proxy_bind {{ 'off' if not proxy['bind'] }}{{ (proxy['bind']['address']) if proxy['bind']['address'] is defined }}{{ ' transparent' if proxy['bind']['transparent'] is defined and proxy['bind']['transparent'] is boolean }};
+{% endif %}
+{% if proxy['buffer_size'] is defined %}
+proxy_buffer_size {{ proxy['buffer_size'] }};
+{% endif %}
+{% if proxy['buffering'] is defined and proxy['buffering'] is boolean %}
+proxy_buffering {{ proxy['buffering'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['buffers'] is defined %}
+proxy_buffers {{ proxy['buffers']['number'] }} {{ proxy['buffers']['size'] }};
+{% endif %}
+{% if proxy['busy_buffers_size'] is defined %}
+proxy_busy_buffers_size {{ proxy['busy_buffers_size'] }};
+{% endif %}
+{% if proxy['cache'] is defined %}
+proxy_cache {{ 'off' if not proxy['cache'] else proxy['cache'] }};
+{% endif %}
+{% if proxy['cache_background_update'] is defined and proxy['cache_background_update'] is boolean %}
+proxy_cache_background_update {{ proxy['cache_background_update'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['cache_bypass'] is defined and proxy['cache_bypass'] is string %}
+proxy_cache_bypass {{ proxy['cache_bypass'] }};
+{% elif proxy['cache_bypass'] is defined and proxy['cache_bypass'] is iterable and proxy['cache_bypass'][0] is string %}
+proxy_cache_bypass {{ proxy['cache_bypass'] | join(' ') }};
+{% elif proxy['cache_bypass'] is defined and proxy['cache_bypass'] is iterable %}
+{% for bypass in proxy['cache_bypass'] %}
+{% if bypass is not string %}
+proxy_cache_bypass {{ bypass | join(' ') }};
+{% else %}
+proxy_cache_bypass {{ bypass }};
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if proxy['cache_convert_head'] is defined and proxy['cache_convert_head'] is boolean %}
+proxy_cache_convert_head {{ proxy['cache_convert_head'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['cache_key'] is defined %}
+proxy_cache_key {{ proxy['cache_key'] }};
+{% endif %}
+{% if proxy['cache_lock'] is defined and proxy['cache_lock'] is boolean %}
+proxy_cache_lock {{ proxy['cache_lock'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['cache_lock_age'] is defined %}
+proxy_cache_lock_age {{ proxy['cache_lock_age'] }};
+{% endif %}
+{% if proxy['cache_lock_timeout'] is defined %}
+proxy_cache_lock_timeout {{ proxy['cache_lock_timeout'] }};
+{% endif %}
+{% if proxy['cache_max_range_offset'] is defined %}
+proxy_cache_max_range_offset {{ proxy['cache_max_range_offset'] }};
+{% endif %}
+{% if proxy['cache_methods'] is defined %}
+proxy_cache_methods {{ proxy['cache_methods'] if proxy['cache_methods'] is string else proxy['cache_methods'] | join(' ') }};
+{% endif %}
+{% if proxy['cache_min_uses'] is defined %}
+proxy_cache_min_uses {{ proxy['cache_min_uses'] }};
+{% endif %}
+{% if proxy['cache_purge'] is defined and proxy['cache_purge'] is string %}
+proxy_cache_purge {{ proxy['cache_purge'] }};
+{% elif proxy['cache_purge'] is defined and proxy['cache_purge'] is iterable %}
+proxy_cache_purge {{ proxy['cache_purge'] | join(' ') }};
+{% endif %}
+{% if proxy['cache_revalidate'] is defined and proxy['cache_revalidate'] is boolean %}
+proxy_cache_revalidate {{ proxy['cache_revalidate'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['cache_use_stale'] is defined %}
+proxy_cache_use_stale {{ 'off' if not proxy['cache_use_stale'] else (proxy['cache_use_stale'] if proxy['cache_use_stale'] is string else proxy['cache_use_stale'] | join(' ')) }};
+{% endif %}
+{% if proxy['cache_valid'] is defined %}
+{% for proxy in proxy['cache_valid'] %}
+proxy_cache_valid{{ ' ' + ((proxy['code'] | join(' ') | string) if proxy['code'] is iterable else proxy['code'] | string) if proxy['code'] is defined }}{{ ' ' + proxy['time'] | string }};
+{% endfor %}
+{% endif %}
+{% if proxy['connect_timeout'] is defined %}
+proxy_connect_timeout {{ proxy['connect_timeout'] }};
+{% endif %}
+{% if proxy['cookie_domain'] is defined and proxy['cookie_domain'] is iterable and proxy['cookie_domain'] is not string %}
+{% for domain in proxy['cookie_domain'] %}
+proxy_cookie_domain {{ 'off' if not domain }}{{ domain['domain'] if domain['domain'] is defined }}{{ (' ' + domain['replacement']) if domain['replacement'] is defined }};
+{% endfor %}
+{% elif proxy['cookie_domain'] is defined %}
+proxy_cookie_domain {{ 'off' if not proxy['cookie_domain'] }}{{ proxy['cookie_domain']['domain'] if proxy['cookie_domain']['domain'] is defined }}{{ (' ' + proxy['cookie_domain']['replacement']) if proxy['cookie_domain']['replacement'] is defined }};
+{% endif %}
+{% if proxy['cookie_flags'] is defined and proxy['cookie_flags'] is iterable and proxy['cookie_flags'] is not string %}
+{% for flag in proxy['cookie_flags'] %}
+proxy_cookie_flags {{ 'off' if not flag }}{{ flag['cookie'] if flag['cookie'] is defined }}{{ (' ' + (flag['flag'] | join(' '))) if flag['flag'] is defined }};
+{% endfor %}
+{% elif proxy['cookie_flags'] is defined %}
+proxy_cookie_flags {{ 'off' if not proxy['cookie_flags'] }}{{ proxy['cookie_flags']['cookie'] if proxy['cookie_flags']['cookie'] is defined }}{{ (' ' + (proxy['cookie_flags']['flag'] | join(' '))) if proxy['cookie_flags']['flag'] is defined }};
+{% endif %}
+{% if proxy['cookie_path'] is defined and proxy['cookie_path'] is iterable and proxy['cookie_path'] is not string %}
+{% for path in proxy['cookie_path'] %}
+proxy_cookie_path {{ 'off' if not path }}{{ path['path'] if path['path'] is defined }}{{ (' ' + path['replacement']) if path['replacement'] is defined }};
+{% endfor %}
+{% elif proxy['cookie_path'] is defined %}
+proxy_cookie_path {{ 'off' if not proxy['cookie_path'] }}{{ proxy['cookie_path']['path'] if proxy['cookie_path']['path'] is defined }}{{ (' ' + proxy['cookie_path']['replacement']) if proxy['cookie_path']['replacement'] is defined }};
+{% endif %}
+{% if proxy['force_ranges'] is defined and proxy['force_ranges'] is boolean %}
+proxy_force_ranges {{ proxy['force_ranges'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['headers_hash_bucket_size'] is defined %}
+proxy_headers_hash_bucket_size {{ proxy['headers_hash_bucket_size'] }};
+{% endif %}
+{% if proxy['headers_hash_max_size'] is defined %}
+proxy_headers_hash_max_size {{ proxy['headers_hash_max_size'] }};
+{% endif %}
+{% if proxy['hide_header'] is defined and proxy['hide_header'] is string %}
+proxy_hide_header {{ proxy['hide_header'] }};
+{% elif proxy['hide_header'] is defined and proxy['hide_header'] is iterable and proxy['hide_header'] is not string %}
+{% for header in proxy['hide_header'] %}
+proxy_hide_header {{ header }};
+{% endfor %}
+{% endif %}
+{% if proxy['http_version'] is defined %}
+proxy_http_version {{ proxy['http_version'] }};
+{% endif %}
+{% if proxy['ignore_client_abort'] is defined and proxy['ignore_client_abort'] is boolean %}
+proxy_ignore_client_abort {{ proxy['ignore_client_abort'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['ignore_headers'] is defined %}
+proxy_ignore_headers {{ proxy['ignore_headers'] if proxy['ignore_headers'] is string else proxy['ignore_headers'] | join(' ') }};
+{% endif %}
+{% if proxy['intercept_errors'] is defined and proxy['intercept_errors'] is boolean %}
+proxy_intercept_errors {{ proxy['intercept_errors'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['limit_rate'] is defined %}
+proxy_limit_rate {{ proxy['limit_rate'] }};
+{% endif %}
+{% if proxy['max_temp_file_size'] is defined %}
+proxy_max_temp_file_size {{ proxy['max_temp_file_size'] }};
+{% endif %}
+{% if proxy['method'] is defined %}
+proxy_method {{ proxy['method'] }};
+{% endif %}
+{% if proxy['next_upstream'] is defined %}
+proxy_next_upstream {{ 'off' if not proxy['next_upstream'] else (proxy['next_upstream'] if proxy['next_upstream'] is string else proxy['next_upstream'] | join(' ')) }};
+{% endif %}
+{% if proxy['next_upstream_timeout'] is defined %}
+proxy_next_upstream_timeout {{ proxy['next_upstream_timeout'] }};
+{% endif %}
+{% if proxy['next_upstream_tries'] is defined %}
+proxy_next_upstream_tries {{ proxy['next_upstream_tries'] }};
+{% endif %}
+{% if proxy['no_cache'] is defined %}
+proxy_no_cache {{ proxy['no_cache'] if proxy['no_cache'] is string else proxy['no_cache'] | join(' ') }};
+{% endif %}
+{% if proxy['pass_header'] is defined %}
+{% for header in proxy['pass_header'] %}
+proxy_pass_header {{ header }};
+{% endfor %}
+{% endif %}
+{% if proxy['pass_request_body'] is defined and proxy['pass_request_body'] is boolean %}
+proxy_pass_request_body {{ proxy['pass_request_body'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['pass_request_headers'] is defined and proxy['pass_request_headers'] is boolean %}
+proxy_pass_request_headers {{ proxy['pass_request_headers'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['read_timeout'] is defined and proxy['read_timeout'] is boolean %}
+proxy_read_timeout {{ proxy['read_timeout'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['redirect'] is defined and proxy['redirect'] is iterable and proxy['redirect'] is not string %}
+{% for redirect in proxy['redirect'] %}
+proxy_redirect {{ (redirect['original'] + ' ' + redirect['replacement']) if redirect['original'] is defined else redirect }};
+{% endfor %}
+{% elif proxy['redirect'] is defined %}
+proxy_redirect {{ (proxy['redirect']['original'] + ' ' + proxy['redirect']['replacement']) if proxy['redirect']['original'] is defined else ('off' if not proxy['redirect'] else proxy['redirect']) }};
+{% endif %}
+{% if proxy['request_buffering'] is defined and proxy['request_buffering'] is boolean %}
+proxy_request_buffering {{ proxy['request_buffering'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['send_lowat'] is defined %}
+proxy_send_lowat {{ proxy['send_lowat'] }};
+{% endif %}
+{% if proxy['send_timeout'] is defined %}
+proxy_send_timeout {{ proxy['send_timeout'] }};
+{% endif %}
+{% if proxy['set_body'] is defined %}
+proxy_set_body {{ proxy['set_body'] }};
+{% endif %}
+{% if proxy['set_header'] is defined %}
+{% for header in proxy['set_header'] %}
+proxy_set_header {{ header['field'] }} {{ header['value'] }};
+{% endfor %}
+{% endif %}
+{% if proxy['socket_keepalive'] is defined and proxy['socket_keepalive'] is boolean %}
+proxy_socket_keepalive {{ proxy['socket_keepalive'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['ssl_certificate'] is defined %}
+proxy_ssl_certificate {{ proxy['ssl_certificate'] }};
+{% endif %}
+{% if proxy['ssl_certificate_key'] is defined %}
+proxy_ssl_certificate_key {{ proxy['ssl_certificate_key'] }};
+{% endif %}
+{% if proxy['ssl_ciphers'] is defined %}
+proxy_ssl_ciphers {{ proxy['ssl_ciphers'] if proxy['ssl_ciphers'] is string else proxy['ssl_ciphers'] | join(':') }};
+{% endif %}
+{% if proxy['ssl_conf_command'] is defined and proxy['ssl_conf_command'] is iterable and proxy['ssl_conf_command'] is not string %}
+{% for command in proxy['ssl_conf_command'] %}
+proxy_ssl_conf_command {{ command }};
+{% endfor %}
+{% elif proxy['ssl_conf_command'] is defined and proxy['ssl_conf_command'] is string %}
+proxy_ssl_conf_command {{ proxy['ssl_conf_command'] }};
+{% endif %}
+{% if proxy['ssl_crl'] is defined %}
+proxy_ssl_crl {{ proxy['ssl_crl'] }};
+{% endif %}
+{% if proxy['ssl_name'] is defined %}
+proxy_ssl_name {{ proxy['ssl_name'] }};
+{% endif %}
+{% if proxy['ssl_password_file'] is defined %}
+proxy_ssl_password_file {{ proxy['ssl_password_file'] }};
+{% endif %}
+{% if proxy['ssl_protocols'] is defined %}
+proxy_ssl_protocols {{ proxy['ssl_protocols'] if proxy['ssl_protocols'] is string else proxy['ssl_protocols'] | join(' ') }};
+{% endif %}
+{% if proxy['ssl_server_name'] is defined and proxy['ssl_server_name'] is boolean %}
+proxy_ssl_server_name {{ proxy['ssl_server_name'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['ssl_session_reuse'] is defined and proxy['ssl_session_reuse'] is boolean %}
+proxy_ssl_session_reuse {{ proxy['ssl_session_reuse'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['ssl_trusted_certificate'] is defined %}
+proxy_ssl_trusted_certificate {{ proxy['ssl_trusted_certificate'] }};
+{% endif %}
+{% if proxy['ssl_verify'] is defined and proxy['ssl_verify'] is boolean %}
+proxy_ssl_verify {{ proxy['ssl_verify'] | ternary('on', 'off') }};
+{% endif %}
+{% if proxy['ssl_verify_depth'] is defined %}
+proxy_ssl_verify_depth {{ proxy['ssl_verify_depth'] }};
+{% endif %}
+{% if proxy['store'] is defined %}
+proxy_store {{ (proxy['store'] | ternary('on', 'off')) if proxy['store'] is boolean else proxy['store'] }};
+{% endif %}
+{% if proxy['store_access'] is defined %}
+proxy_store_access{{ ' user:' + proxy['store_access']['user'] if proxy['store_access']['user'] is defined -}}
+{{- ' group:' + proxy['store_access']['group'] if proxy['store_access']['group'] is defined -}}
+{{- ' all:' + proxy['store_access']['all'] if proxy['store_access']['all'] is defined }};
+{% endif %}
+{% if proxy['temp_file_write_size'] is defined %}
+proxy_temp_file_write_size {{ proxy['temp_file_write_size'] }};
+{% endif %}
+{% if proxy['temp_path']['path'] is defined %}
+proxy_temp_path {{ proxy['temp_path']['path'] -}}
+{{- ' 1' if proxy['temp_path']['level'] is defined and proxy['temp_path']['level'] == 1 -}}
+{{- ' 1 2' if proxy['temp_path']['level'] is defined and proxy['temp_path']['level'] == 2 -}}
+{{- ' 1 2 3' if proxy['temp_path']['level'] is defined and proxy['temp_path']['level'] == 3 }};
+{% endif %}
+{% endmacro %}
+
+{% macro proxy_pass(proxy) %}
+proxy_pass {{ proxy }};
+{% endmacro %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -62,6 +62,12 @@ http {
     {{ grpc_global(nginx_config_main_template.http_settings.grpc_global) }}
 {% endfilter %}
 {% endif %}
+{% if nginx_config_main_template.http_settings.gzip is defined %}
+{% from 'http/gzip.j2' import gzip with context %}
+{% filter indent(4) %}
+    {{ gzip(nginx_config_main_template.http_settings.gzip) }}
+{% endfilter %}
+{% endif %}
 {% for access_log in nginx_config_main_template.http_settings.access_log_format %}
     log_format  {{ access_log.name }}  {{ access_log.format }};
 {% endfor %}
@@ -75,7 +81,7 @@ http {
 {% endif %}
 {% endif %}
 {% if nginx_config_main_template.http_settings.sendfile is defined and nginx_config_main_template.http_settings.sendfile %}
-sendfile        on;
+    sendfile        on;
 {% endif %}
 {% if nginx_config_main_template.http_settings.tcp_nopush is defined and nginx_config_main_template.http_settings.tcp_nopush %}
     tcp_nopush      on;
@@ -87,15 +93,6 @@ sendfile        on;
     server_tokens {{ nginx_config_main_template.http_settings.server_tokens }};
 {% endif %}
     keepalive_timeout  {{ nginx_config_main_template.http_settings.keepalive_timeout }};
-{% if nginx_config_main_template.http_settings.gzip is defined %}
-{% from 'http/gzip.j2' import gzip with context %}
-{% filter indent(4) %}
-    {{ gzip(nginx_config_main_template.http_settings.gzip) }}
-{% endfilter %}
-{% endif %}
-{% if nginx_config_main_template.http_settings.cache is defined %}
-    proxy_cache_path /tmp/cache keys_zone=one:10m;
-{% endif %}
 {% if nginx_config_main_template.http_settings.rate_limit is defined %}
     limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
 {% endif %}


### PR DESCRIPTION
### Proposed changes
Refactor the `proxy` HTTP config template into its own separate file. All variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
*   All `proxy_*` related variables now live under the `proxy` dictionary key, with the exception of `proxy_pass` and `proxy_cache_path`. You can specify the `proxy` dictionary key inside the `http`, `server`, and `location` contexts.
*   Remove the `nginx_config_main_template.http_settings.cache` dictionary variable. Use `nginx_config_http_template.*.proxy_cache_path` instead.
*   Remove the `location.websocket` variable. Use `location.proxy.set_header` instead:
```yaml
proxy:
  set_header:
    - field: Upgrade
      value: $http_upgrade
    - field: Connection
      value: Upgrade
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
