### PR TITLE
feat: make http settings access_log_format and keepalive_timeout optional

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -68,9 +68,11 @@ http {
     {{ gzip(nginx_config_main_template.http_settings.gzip) }}
 {% endfilter %}
 {% endif %}
+{% if nginx_config_main_template.http_settings.access_log_format is defined %}
 {% for access_log in nginx_config_main_template.http_settings.access_log_format %}
     log_format  {{ access_log.name }}  {{ access_log.format }};
 {% endfor %}
+{% endif %}
 {% if nginx_config_main_template.http_settings.access_log_location is defined %}
 {% if nginx_config_main_template.http_settings.access_log_location is sameas false or nginx_config_main_template.http_settings.access_log_location == "off" %}
     access_log off;
@@ -92,7 +94,9 @@ http {
 {% if nginx_config_main_template.http_settings.server_tokens is defined and nginx_config_main_template.http_settings.server_tokens | length %}
     server_tokens {{ nginx_config_main_template.http_settings.server_tokens }};
 {% endif %}
+{% if nginx_config_main_template.http_settings.keepalive_timeout is defined %}
     keepalive_timeout  {{ nginx_config_main_template.http_settings.keepalive_timeout }};
+{% endif %}
 {% if nginx_config_main_template.http_settings.rate_limit is defined %}
     limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
 {% endif %}


### PR DESCRIPTION
### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

Make the following `http_settings` options:
1. `access_log_format`
2. `keepalive_timeout`

So that I can configure the main template like this (to enable the HTTP directive):
```yaml
nginx_config_main_template_enable: true
nginx_config_main_template:
  http_enable: true
  http_settings:
    gzip:
      enable: true
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)

**NOTE**: Let me know if I need to add some tests and where.