### PR TITLE
Tweak Molecule tests to account for the current supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ ENHANCEMENTS:
 *   Consolidate Molecule testing scenarios to address changes introduced in Ansible Lint `5.*`.
 *   Specify GitHub actions Ubuntu release.
 *   Minor GitHub template tweaks, including the creation of a SECURITY doc.
+*   Replace Molecule tests using Alpine 3.11 with Alpine 3.10 (to test NGINX App Protect configurations), Debian stretch with Debian buster (stretch has reached its EoL), and update list of supported platforms.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Alpine:
   - 3.10
   - 3.11
   - 3.12
+  - 3.13
 CentOS:
   - 7.4+
   - 8
 Debian:
-  - stretch
   - buster
 RedHat:
   - 7.4+
@@ -84,6 +84,7 @@ Alpine:
   - 3.10
   - 3.11
   - 3.12
+  - 3.13
 Amazon Linux:
   - 2018.03
 Amazon Linux 2:
@@ -92,7 +93,6 @@ CentOS:
   - 7.4+
   - 8
 Debian:
-  - stretch
   - buster
 FreeBSD:
   - 11.2+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,7 +22,6 @@ galaxy_info:
         - any
     - name: Debian
       versions:
-        - stretch
         - buster
     - name: EL
       versions:

--- a/molecule/cleanup_module/molecule.yml
+++ b/molecule/cleanup_module/molecule.yml
@@ -10,8 +10,8 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
+  - name: alpine-3.10
+    image: alpine:3.10
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:
@@ -24,8 +24,8 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: debian-stretch
-    image: debian:stretch-slim
+  - name: debian-buster
+    image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/common/requirements/plus_requirements.yml
+++ b/molecule/common/requirements/plus_requirements.yml
@@ -3,4 +3,4 @@ roles:
   - name: nginxinc.nginx
     version: 0.19.1
   - name: nginxinc.nginx_app_protect
-    version: 0.4.2
+    src: https://github.com/nginxinc/ansible-role-nginx-app-protect.git

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,8 +10,8 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
+  - name: alpine-3.10
+    image: alpine:3.10
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:
@@ -24,8 +24,8 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: debian-stretch
-    image: debian:stretch-slim
+  - name: debian-buster
+    image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -10,6 +10,13 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
+  - name: alpine-3.10
+    image: alpine:3.10
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
@@ -17,8 +24,8 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: debian-stretch
-    image: debian:stretch-slim
+  - name: debian-buster
+    image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/plus/verify.yml
+++ b/molecule/plus/verify.yml
@@ -19,22 +19,28 @@
       register: service
       failed_when: (service is changed) or (service is failed)
 
-    - name: Check that a page returns a status 200 and fail if the words Hello World are not in the page contents
-      uri:
-        url: http://localhost
-        return_content: yes
-      register: this
-      failed_when: "'Hello World' not in this.content"
+    - name: Functional tests
+      block:
+        - name: Check that a page returns a status 200 and fail if the words Hello World are not in the page contents
+          uri:
+            url: "http://localhost"
+            return_content: yes
+          register: this
+          failed_when: "'Hello World' not in this.content"
 
-    - name: Check that a page returns a status 200 and fail if the words Request Rejected are not in the page contents
-      uri:
-        url: http://localhost/?v=<script>
-        return_content: yes
-      register: this
-      until: "'Request Rejected' not in this.content"
-      retries: 15
-      delay: 10
-      # failed_when: "'Request Rejected' not in this.content"
+        - name: Check that a page returns a status 200 and fail if the words Request Rejected are not in the page contents
+          uri:
+            url: "http://localhost/?v=<script>"
+            return_content: yes
+          register: this
+          failed_when: "'Request Rejected' not in this.content"
+
+        - name: Ensure /var/log/messages contains block event from above test
+          shell: grep -c "Non-browser Client,Abuse of Functionality,Cross Site Scripting (XSS)" /var/log/messages || true
+          register: event
+          changed_when: false
+          failed_when: event.stdout == "0"
+      when: ansible_os_family != "Alpine"
 
     - name: Check default.conf exists
       stat:

--- a/molecule/plus/verify.yml
+++ b/molecule/plus/verify.yml
@@ -31,7 +31,10 @@
         url: http://localhost/?v=<script>
         return_content: yes
       register: this
-      failed_when: "'Request Rejected' not in this.content"
+      until: "'Request Rejected' not in this.content"
+      retries: 15
+      delay: 10
+      # failed_when: "'Request Rejected' not in this.content"
 
     - name: Check default.conf exists
       stat:

--- a/molecule/stable_push/molecule.yml
+++ b/molecule/stable_push/molecule.yml
@@ -10,8 +10,8 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
+  - name: alpine-3.10
+    image: alpine:3.10
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:
@@ -24,8 +24,8 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: debian-stretch
-    image: debian:stretch-slim
+  - name: debian-buster
+    image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:


### PR DESCRIPTION
### Proposed changes
Replace Molecule tests using Alpine 3.11 with Alpine 3.10 (to test NGINX App Protect configurations), Debian stretch with Debian buster (stretch has reached its EoL), and update list of supported platforms.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
