### PR TITLE
Add `server_names_hash_bucket_size` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ BREAKING CHANGES:
     *   Rename `proxy_hide_headers` to `proxy_hide_header`.
     *   Rename `html_file_location` to `root`.
     *   Rename `html_file_name` to `index`.
+*   Add [`server_names_hash_bucket_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) and [`server_names_hash_max_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directives.
 
 DEPRECATION WARNINGS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ BREAKING CHANGES:
     *   Rename `proxy_hide_headers` to `proxy_hide_header`.
     *   Rename `html_file_location` to `root`.
     *   Rename `html_file_name` to `index`.
-*   Add [`server_names_hash_bucket_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) and [`server_names_hash_max_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directives.
 
 DEPRECATION WARNINGS:
 
@@ -61,6 +60,7 @@ ENHANCEMENTS:
 *   Specify GitHub actions Ubuntu release.
 *   Minor GitHub template tweaks, including the creation of a SECURITY doc.
 *   Replace Molecule tests using Alpine 3.11 with Alpine 3.10 (to test NGINX App Protect configurations), Debian stretch with Debian buster (stretch has reached its EoL), and update list of supported platforms.
+*   Add [`server_names_hash_bucket_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) and [`server_names_hash_max_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directives.
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -106,6 +106,8 @@ nginx_config_main_template:
     rate_limit: false
     keyval: false
     server_tokens: "off"
+    server_names_hash_bucket_size: 64
+    server_names_hash_max_size: 512
   http_global_autoindex: false
   sub_filter:
     # sub_filters: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -89,6 +89,8 @@
             rate_limit: false
             keyval: false
             server_tokens: "off"
+            server_names_hash_bucket_size: 64
+            server_names_hash_max_size: 512
           sub_filter:
             last_modified: false
             once: true

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -95,6 +95,8 @@
             rate_limit: false
             keyval: false
             server_tokens: "off"
+            server_names_hash_bucket_size: 64
+            server_names_hash_max_size: 512
           sub_filter:
             last_modified: false
             once: true

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -104,6 +104,12 @@ http {
     keyval_zone zone={{nginx_config_main_template.http_settings.keyval.zone}}:32k state=one.keyval;
     keyval $arg_text $text zone=one;
 {% endif %}
+{% if nginx_config_main_template.http_settings.server_names_hash_bucket_size is defined %}
+    server_names_hash_bucket_size  {{ nginx_config_main_template.http_settings.server_names_hash_bucket_size }};
+{% endif %}
+{% if nginx_config_main_template.http_settings.server_names_hash_max_size is defined %}
+    server_names_hash_max_size  {{ nginx_config_main_template.http_settings.server_names_hash_max_size }};
+{% endif %}
 {% if nginx_config_main_template.http_global_autoindex is defined | default(false) %}
     autoindex on;
 {% endif %}


### PR DESCRIPTION
### Proposed changes

This commit adds two new directives for configuring in nginx.conf.

For completeness, the `server_names_hash_max_size` directive has been added here
as well.

Please see the documentation for these directives
[here](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size).

Please let me know if there's anything that's missing/I still forgot! 🙏

Fixes https://github.com/nginxinc/ansible-role-nginx-config/issues/113

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes (Please see: https://github.com/nginxinc/ansible-role-nginx-config/issues/115)
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
