### PR TITLE
Replace Ansible base with Ansible core

### DIFF
--- a/.github/workflows/requirements/requirements_galaxy.txt
+++ b/.github/workflows/requirements/requirements_galaxy.txt
@@ -1,1 +1,1 @@
-ansible-base==2.10.10
+ansible-core==2.11.1

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,4 +1,4 @@
-ansible-base==2.10.10
+ansible-core==2.11.1
 Jinja2==3.0.1
 ansible-lint==5.0.11
 yamllint==1.26.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ ENHANCEMENTS:
 *   Minor GitHub template tweaks, including the creation of a SECURITY doc.
 *   Replace Molecule tests using Alpine 3.11 with Alpine 3.10 (to test NGINX App Protect configurations), Debian stretch with Debian buster (stretch has reached its EoL), and update list of supported platforms.
 *   Add [`server_names_hash_bucket_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_bucket_size) and [`server_names_hash_max_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_names_hash_max_size) directives.
+*   Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This role configures NGINX Open Source and NGINX Plus on your target host.
 
 ### Ansible
 
-*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible base (bigger than `2.10`) and Ansible (bigger than `2.9.10`).
+*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible core (above `2.11`) and Ansible (above `2.9.10`).
 *   When using Ansible base, you will also need to install the following collections:
     ```yaml
     ---


### PR DESCRIPTION
### Proposed changes
Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
