### PR TITLE
Make proxy_read_timeout a string instead of a boolean

### DIFF
--- a/templates/http/proxy.j2
+++ b/templates/http/proxy.j2
@@ -185,8 +185,8 @@ proxy_pass_request_body {{ proxy['pass_request_body'] | ternary('on', 'off') }};
 {% if proxy['pass_request_headers'] is defined and proxy['pass_request_headers'] is boolean %}
 proxy_pass_request_headers {{ proxy['pass_request_headers'] | ternary('on', 'off') }};
 {% endif %}
-{% if proxy['read_timeout'] is defined and proxy['read_timeout'] is boolean %}
-proxy_read_timeout {{ proxy['read_timeout'] | ternary('on', 'off') }};
+{% if proxy['read_timeout'] is defined %}
+proxy_read_timeout {{ proxy['read_timeout'] }};
 {% endif %}
 {% if proxy['redirect'] is defined and proxy['redirect'] is iterable and proxy['redirect'] is not string %}
 {% for redirect in proxy['redirect'] %}


### PR DESCRIPTION
### Proposed changes
Make proxy_read_timeout a string instead of a boolean. Fixes #134.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
