### PR TITLE
Refactor HTTP auth modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ BREAKING CHANGES:
 *   Refactor the `ssl` HTTP config template into its own separate file. Almost all variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
     *   All `ssl` variables still live within an `ssl` dictionary, but the names have changed to better reflect the official NGINX directive names.
     *   `ssl` configs are now supported within both the `http` and `server` contexts.
+*   Refactor the `auth` HTTP config template into its own separate file, as well as add support for `auth_jwt` directives. All variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
+    *   All the various `auth` variables now live within their respective `auth` dictionaries.
+    *   `auth` configs are now supported within the `http`, `server`, and `location` contexts.
 *   Rename some NGINX template config parameters to align with NGINX directive names:
     *   Rename `html_file_location` to `root`.
     *   Rename `html_file_name` to `index`.

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -133,6 +133,29 @@ nginx_config_http_template:
   - template_file: http/default.conf.j2
     conf_file_name: default.conf
     conf_file_location: /etc/nginx/conf.d/
+    auth_jwt:  # Optional -- Configure JWT auth
+      enable:  # Optional -- Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
+        realm: realm  # Required
+        token: $cookie_auth_token  # Optional
+      claim_set:  # Optional
+        - variable: $email  # Required
+          name:  # Required list or string
+            - info
+      header_set:  # Optional
+        - variable: $job  # Required
+          name: info  # Required list or string
+      key_file: /path/to/file  # Optional
+      key_request: /path/to/file  # Optional
+      leeway: 0s  # Optional
+      type: signed  # Optional -- One of `signed` or `encrypted`
+    auth_request:  # Optional -- Configure request auth
+      uri: false  # Optional -- Set to 'false' to set auth_request to 'off'
+      set:  # Optional
+        variable: $temp  # Required
+        value: auth  # Required
+    auth_basic:  # Optional -- Configure basic auth
+      realm: false  # Optional -- Set to 'false' to set auth_basic to 'off'
+      user_file: /path/to/file  # Optional
     proxy_cache_path:  # Optional -- Configure Proxy Cache Path
       - path: /var/cache/nginx/proxy/backend  # Required
         levels: "1:1"  # Optional
@@ -375,6 +398,22 @@ nginx_config_http_template:
           security_log:  # Optional
             - path: path  # Required
               destination: dest  # Required
+        auth_jwt:  # Optional -- Configure JWT auth
+          enable:  # Optional -- Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
+            realm: realm  # Required
+            token: $cookie_auth_token  # Optional
+          key_file: /path/to/file  # Optional
+          key_request: /path/to/file  # Optional
+          leeway: 0s  # Optional
+          type: signed  # Optional -- One of `signed` or `encrypted`
+        auth_request:  # Optional -- Configure request auth
+          uri: false  # Optional -- Set to 'false' to set auth_request to 'off'
+          set:  # Optional
+            variable: $temp  # Required
+            value: auth  # Required
+        auth_basic:  # Optional -- Configure basic auth
+          realm: false  # Optional -- Set to 'false' to set auth_basic to 'off'
+          user_file: /path/to/file  # Optional
         grpc_global:  # Optional -- Configure GRPC
           bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
             address: $remote_addr  # Required
@@ -587,6 +626,22 @@ nginx_config_http_template:
               security_log:  # Optional
                 - path: path  # Required
                   destination: dest  # Required
+              auth_jwt:  # Optional -- Configure JWT auth
+                enable:  # Optional -- Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
+                  realm: realm  # Required
+                  token: $cookie_auth_token  # Optional
+                key_file: /path/to/file  # Optional
+                key_request: /path/to/file  # Optional
+                leeway: 0s  # Optional
+                type: signed  # Optional -- One of `signed` or `encrypted`
+              auth_request:  # Optional -- Configure request auth
+                uri: false  # Optional -- Set to 'false' to set auth_request to 'off'
+                set:  # Optional
+                  variable: $temp  # Required
+                  value: auth  # Required
+              auth_basic:  # Optional -- Configure basic auth
+                realm: false  # Optional -- Set to 'false' to set auth_basic to 'off'
+                user_file: /path/to/file  # Optional
             grpc_global:  # Optional -- Configure GRPC
               bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
                 address: $remote_addr  # Required

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -120,10 +120,6 @@ nginx_config_main_template:
   # events_custom_options: []
   stream_enable: false
   # stream_custom_options: []
-  # auth_request_http: /auth
-  # auth_request_set_http:
-  #   name: $auth_user
-  #   value: $upstream_http_x_user
 
 # Enable creating dynamic templated NGINX HTTP configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase
@@ -592,13 +588,7 @@ nginx_config_http_template:
         index: index.html index.php
         # https_redirect: $host
         autoindex: false
-        auth_basic: null
-        auth_basic_user_file: null
         try_files: $uri $uri/index.html $uri.html =404
-        # auth_request: /auth
-        # auth_request_set:
-        #   name: $auth_user
-        #   value: $upstream_http_x_user
         client_max_body_size: 1m
         add_headers:
           strict_transport_security:
@@ -821,17 +811,11 @@ nginx_config_http_template:
             root: /usr/share/nginx/html
             index: index.html
             autoindex: false
-            auth_basic: null
-            auth_basic_user_file: null
             try_files: $uri $uri/index.html $uri.html =404
             # allows:
             #   - 192.168.1.0/24
             # denies:
             #   - all
-            # auth_request: /auth
-            # auth_request_set:
-            #   name: $auth_user
-            #   value: $upstream_http_x_user
             client_max_body_size: 1m
             # returns:
             #   return302:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -116,6 +116,14 @@
           - template_file: http/default.conf.j2
             conf_file_name: default.conf
             conf_file_location: /etc/nginx/conf.d/
+            auth_request:
+              uri: false
+              set:
+                variable: $temp
+                value: auth
+            auth_basic:
+              realm: false
+              # user_file: not tested
             servers:
               - listen:
                   - ip: 0.0.0.0
@@ -137,6 +145,14 @@
                     opts:
                       - default_server
                 server_name: localhost
+                auth_request:
+                  uri: false
+                  set:
+                    variable: $temp
+                    value: auth
+                auth_basic:
+                  realm: false
+                  # user_file: not tested
                 http_error_pages:
                   404: /404.html
                 error_page: /usr/share/nginx/html
@@ -187,6 +203,14 @@
                   verify_depth: 1
                 locations:
                   - location: /
+                    auth_request:
+                      uri: false
+                      set:
+                        variable: $temp
+                        value: auth
+                    auth_basic:
+                      realm: false
+                      # user_file: not tested
                     grpc:
                       pass: localhost:9000
                     add_headers:

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -219,9 +219,9 @@
                         - path: /etc/app_protect/conf/log_default.json
                           dest: syslog:server=10.1.1.2:514
                     auth_jwt:
-                      enable:
-                        realm: realm
-                        token: $cookie_auth_token
+                      enable: false
+                      #   realm: realm
+                      #   token: $cookie_auth_token
                       # key_file: not tested
                       # key_request: not tested
                       leeway: 0s

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -122,9 +122,9 @@
             conf_file_name: default.conf
             conf_file_location: /etc/nginx/conf.d/
             auth_jwt:
-              enable:
-                realm: realm
-                token: $cookie_auth_token
+              enable: false
+                # realm: realm
+                # token: $cookie_auth_token
               claim_set:
                 - variable: $email
                   name:
@@ -175,9 +175,9 @@
                     - path: /etc/app_protect/conf/log_default.json
                       dest: syslog:server=10.1.1.2:514
                 auth_jwt:
-                  enable: false
-                  #   realm: realm
-                  #   token: $cookie_auth_token
+                  enable:
+                    realm: realm
+                    token: $cookie_auth_token
                   # key_file: not tested
                   # key_request: not tested
                   leeway: 0s

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -121,6 +121,29 @@
           - template_file: http/default.conf.j2
             conf_file_name: default.conf
             conf_file_location: /etc/nginx/conf.d/
+            auth_jwt:
+              enable:
+                realm: realm
+                token: $cookie_auth_token
+              claim_set:
+                - variable: $email
+                  name:
+                    - info
+              header_set:
+                - variable: $job
+                  name: info
+              # key_file: not tested
+              # key_request: not tested
+              leeway: 0s
+              type: signed
+            auth_request:
+              uri: false
+              set:
+                variable: $temp
+                value: auth
+            auth_basic:
+              realm: false
+              # user_file: not tested
             servers:
               - listen:
                   - ip: 0.0.0.0
@@ -151,6 +174,22 @@
                       dest: syslog:server=10.1.1.1:514
                     - path: /etc/app_protect/conf/log_default.json
                       dest: syslog:server=10.1.1.2:514
+                auth_jwt:
+                  enable:
+                    realm: realm
+                    token: $cookie_auth_token
+                  # key_file: not tested
+                  # key_request: not tested
+                  leeway: 0s
+                  type: signed
+                auth_request:
+                  uri: false
+                  set:
+                    variable: $temp
+                    value: auth
+                auth_basic:
+                  realm: false
+                  # user_file: not tested
                 http_error_pages:
                   404: /404.html
                 error_page: /usr/share/nginx/html
@@ -179,6 +218,22 @@
                           dest: syslog:server=10.1.1.1:514
                         - path: /etc/app_protect/conf/log_default.json
                           dest: syslog:server=10.1.1.2:514
+                    auth_jwt:
+                      enable:
+                        realm: realm
+                        token: $cookie_auth_token
+                      # key_file: not tested
+                      # key_request: not tested
+                      leeway: 0s
+                      type: signed
+                    auth_request:
+                      uri: false
+                      set:
+                        variable: $temp
+                        value: auth
+                    auth_basic:
+                      realm: false
+                      # user_file: not tested
                     proxy_hide_header:
                       - X-Powered-By
                     grpc:

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -175,9 +175,9 @@
                     - path: /etc/app_protect/conf/log_default.json
                       dest: syslog:server=10.1.1.2:514
                 auth_jwt:
-                  enable:
-                    realm: realm
-                    token: $cookie_auth_token
+                  enable: false
+                  #   realm: realm
+                  #   token: $cookie_auth_token
                   # key_file: not tested
                   # key_request: not tested
                   leeway: 0s

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -26,7 +26,7 @@ auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['v
 {# HTTP NGINX Auth JWT -- ngx_http_auth_jwt_module #}
 {% macro auth_jwt(auth_jwt) %}
 {% if auth_jwt['enable'] is defined %}
-auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
+auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
 {% endif %}
 {% if auth_jwt['claim_set'] is defined %}
 {% for claim in auth_jwt['claim_set'] %}

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -1,0 +1,53 @@
+{{ ansible_managed | comment }}
+{# NGINX Auth template -- Add directives under its corresponding block #}
+{# Format is as follows #}
+{# Left side (context module_name) -- Right side (module name) #}
+
+{# HTTP NGINX Auth Basic -- ngx_http_auth_basic_module #}
+{% macro auth_basic(auth_basic) %}
+{% if auth_basic['realm'] is defined %}
+auth_basic {{ 'off' if not auth_basic['realm'] else auth_basic['realm'] }};
+{% endif %}
+{% if auth_basic['user_file'] is defined %}
+auth_basic_user_file {{ auth_basic['user_file'] }};
+{% endif %}
+{% endmacro %}
+
+{# HTTP NGINX Auth Request -- ngx_http_auth_request_module #}
+{% macro auth_request(auth_request) %}
+{% if auth_request['uri'] is defined %}
+auth_request {{ 'off' if not auth_request['uri'] else auth_request['uri'] }};
+{% endif %}
+{% if auth_request['set'] is defined %}
+auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['value'] }};
+{% endif %}
+{% endmacro %}
+
+{# HTTP NGINX Auth JWT -- ngx_http_auth_jwt_module #}
+{% macro auth_jwt(auth_jwt) %}
+{% if auth_jwt['enable'] is defined %}
+auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
+{% endif %}
+{% if auth_jwt['claim_set'] is defined %}
+{% for claim in auth_jwt['claim_set'] %}
+auth_jwt_claim_set {{ claim['variable'] }} {{ (claim['name'] if claim['name'] is string else claim['name'] | join(' ')) }};
+{% endfor %}
+{% endif %}
+{% if auth_jwt['header_set'] is defined %}
+{% for claim in auth_jwt['header_set'] %}
+auth_jwt_header_set {{ claim['variable'] }} {{ (claim['name'] if claim['name'] is string else claim['name'] | join(' ')) }};
+{% endfor %}
+{% endif %}
+{% if auth_jwt['key_file'] is defined %}
+auth_jwt_key_file {{ auth_jwt['key_file'] }};
+{% endif %}
+{% if auth_jwt['key_request'] is defined %}
+auth_jwt_key_request {{ auth_jwt['key_request'] }};
+{% endif %}
+{% if auth_jwt['leeway'] is defined %}
+auth_jwt_leeway {{ auth_jwt['leeway'] }};
+{% endif %}
+{% if auth_jwt['type'] is defined %}
+auth_jwt_type {{ auth_jwt['type'] }};
+{% endif %}
+{% endmacro %}

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -26,7 +26,7 @@ auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['v
 {# HTTP NGINX Auth JWT -- ngx_http_auth_jwt_module #}
 {% macro auth_jwt(auth_jwt) %}
 {% if auth_jwt['enable'] is defined %}
-auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
+auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ (auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined) + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
 {% endif %}
 {% if auth_jwt['claim_set'] is defined %}
 {% for claim in auth_jwt['claim_set'] %}

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -26,7 +26,7 @@ auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['v
 {# HTTP NGINX Auth JWT -- ngx_http_auth_jwt_module #}
 {% macro auth_jwt(auth_jwt) %}
 {% if auth_jwt['enable'] is defined %}
-auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ (auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined) + (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
+auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined }}{{ (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
 {% endif %}
 {% if auth_jwt['claim_set'] is defined %}
 {% for claim in auth_jwt['claim_set'] %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -70,7 +70,7 @@ server {
 {% if server.auth_jwt is defined %}
 {% from 'http/auth.j2' import auth_jwt with context %}
 {% filter indent(4) %}
-      {{ auth_jwt(server.auth_jwt) }}
+    {{ auth_jwt(server.auth_jwt) }}
 {% endfilter %}
 {% endif %}
 {% if server.grpc_global is defined %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -17,11 +17,17 @@
 {{ ssl(item.ssl) }}
 {% endif %}
 
-{% if item.auth_request_http is defined %}
-auth_request {{ item.auth_request_http }};
+{% if item.auth_request is defined %}
+{% from 'http/auth.j2' import auth_request with context %}
+{{ auth_request(item.auth_request) }}
 {% endif %}
-{% if item.auth_request_set_http is defined %}
-auth_request_set {{ item.auth_request_set_http.name }} {{ item.auth_request_set_http.value }};
+{% if item.auth_basic is defined %}
+{% from 'http/auth.j2' import auth_basic with context %}
+{{ auth_basic(item.auth_basic) }}
+{% endif %}
+{% if item.auth_jwt is defined %}
+{% from 'http/auth.j2' import auth_jwt with context %}
+{{ auth_jwt(item.auth_jwt) }}
 {% endif %}
 
 {% if item.custom_options is defined and item.custom_options | length %}
@@ -47,6 +53,24 @@ server {
 {% from 'http/app_protect.j2' import app_protect_local with context %}
 {% filter indent(4) %}
     {{ app_protect_local(server.app_protect) }}
+{% endfilter %}
+{% endif %}
+{% if server.auth_request is defined %}
+{% from 'http/auth.j2' import auth_request with context %}
+{% filter indent(4) %}
+    {{ auth_request(server.auth_request) }}
+{% endfilter %}
+{% endif %}
+{% if server.auth_basic is defined %}
+{% from 'http/auth.j2' import auth_basic with context %}
+{% filter indent(4) %}
+    {{ auth_basic(server.auth_basic) }}
+{% endfilter %}
+{% endif %}
+{% if server.auth_jwt is defined %}
+{% from 'http/auth.j2' import auth_jwt with context %}
+{% filter indent(4) %}
+      {{ auth_jwt(server.auth_jwt) }}
 {% endfilter %}
 {% endif %}
 {% if server.grpc_global is defined %}
@@ -77,12 +101,6 @@ server {
     add_header {{ server.add_headers[header].name }} "{{ server.add_headers[header].value }}"{% if server.add_headers[header].always is defined and server.add_headers[header].always %} always{% endif %};
 {% endfor %}
 {% endif %}
-{% if server.auth_basic is defined %}
-    auth_basic "{{ server.auth_basic }}";
-{% endif %}
-{% if server.auth_basic_user_file is defined %}
-    auth_basic_user_file {{ server.auth_basic_user_file }};
-{% endif %}
 {% if server.root is defined %}
     root {{ server.root }};
 {% endif %}
@@ -97,12 +115,6 @@ server {
 {% endif %}
 {% if server.try_files is defined %}
     try_files {{ server.try_files }};
-{% endif %}
-{% if server.auth_request is defined %}
-    auth_request {{ server.auth_request }};
-{% endif %}
-{% if server.auth_request_set is defined %}
-    auth_request_set {{ server.auth_request_set.name }} {{ server.auth_request_set.value }};
 {% endif %}
 {% if server.client_max_body_size is defined %}
     client_max_body_size {{ server.client_max_body_size }};
@@ -136,6 +148,24 @@ server {
 {% from 'http/app_protect.j2' import app_protect_local with context %}
 {% filter indent(8) %}
         {{ app_protect_local(location.app_protect) }}
+{% endfilter %}
+{% endif %}
+{% if location.auth_request is defined %}
+{% from 'http/auth.j2' import auth_request with context %}
+{% filter indent(8) %}
+        {{ auth_request(location.auth_request) }}
+{% endfilter %}
+{% endif %}
+{% if location.auth_basic is defined %}
+{% from 'http/auth.j2' import auth_basic with context %}
+{% filter indent(8) %}
+        {{ auth_basic(location.auth_basic) }}
+{% endfilter %}
+{% endif %}
+{% if location.auth_jwt is defined %}
+{% from 'http/auth.j2' import auth_jwt with context %}
+{% filter indent(8) %}
+        {{ auth_jwt(location.auth_jwt) }}
 {% endfilter %}
 {% endif %}
 {% if location.grpc_global is defined %}
@@ -186,18 +216,6 @@ server {
 {% for header in location.add_headers %}
         add_header {{ location.add_headers[header].name }} "{{ location.add_headers[header].value }}"{% if location.add_headers[header].always is defined and location.add_headers[header].always %} always{% endif %};
 {% endfor %}
-{% endif %}
-{% if location.auth_request is defined %}
-        auth_request {{ location.auth_request }};
-{% endif %}
-{% if location.auth_request_set is defined %}
-        auth_request_set {{ location.auth_request_set.name }} {{ location.auth_request_set.value }};
-{% endif %}
-{% if location.auth_basic is defined %}
-        auth_basic "{{ location.auth_basic }}";
-{% endif %}
-{% if location.auth_basic_user_file is defined %}
-        auth_basic_user_file {{ location.auth_basic_user_file }};
 {% endif %}
 {% if location.returns is defined %}
 {% for code in location.returns %}


### PR DESCRIPTION
### Proposed changes
Refactor the `auth` HTTP config template into its own separate file, as well as add support for `auth_jwt` directives. All variables have changed (check [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml) for examples):
    *   All the various `auth` variables now live within their respective `auth` dictionaries.
    *   `auth` configs are now supported within the `http`, `server`, and `location` contexts.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
