### PR TITLE
Fix default template for nginx.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ ENHANCEMENTS:
 *   Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
 *   Update GitHub actions to add a workflow dispatch option.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
+*   Ensure the default values for the `nginx.conf` template match the default values found on a fresh NGINX installation.
 
 BUG FIXES:
 
@@ -81,6 +82,7 @@ BUG FIXES:
 *   In NGINX App Protect environments on SELinux enforced systems, the `nginx -t` handler fails when run from a directory that the NGINX process' user does not have access to.
 *   Fix missing GRPC boolean check in GRPC template.
 *   Fix `nginx_config_cleanup_paths` not working as intended.
+*   Fix issue with the `app_protect.j2` template that was causing the default values for `nginx.conf` to fail.
 
 ## 0.3.3 (January 28, 2021)
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -13,107 +13,107 @@ nginx_config_main_template_enable: false
 nginx_config_main_template:
   template_file: nginx.conf.j2
   conf_file_name: nginx.conf
-  conf_file_location: /etc/nginx/
+  conf_file_location: /etc/nginx
   # modules:  # specify modules as a list following the format in the line below
   #   - modules/ngx_http_js_module.so
   user: nginx
   worker_processes: auto
-  worker_rlimit_nofile: 1024
+  # worker_rlimit_nofile: 1024
   pid: /var/run/nginx.pid
   error_log:
     location: /var/log/nginx/error.log
-    level: warn
+    level: notice
   worker_connections: 1024
   http_enable: true
   http_settings:
-    app_protect_global:  # Optional -- Configure NGINX App Protect
-      physical_memory_util_thresholds:  # Optional
-        high: 100  # Required
-        low: 100  # Required
-      cpu_thresholds:  # Optional
-        high: 100  # Required
-        low: 100  # Required
-      failure_mode_action: pass  # Optional -- 'pass' or 'drop'
-      cookie_seed: encryptionseed  # Optional
-      compressed_requests_action: drop  # Optional -- 'pass' or 'drop'
-      request_buffer_overflow_action: pass  # Optional -- 'pass' or 'drop'
-      user_defined_signatures: []  # Optional list
-    app_protect:  # Optional -- Configure NGINX App Protect
-      enable: false  # Optional boolean
-      policy_file: path  # Optional
-      security_log_enable: false  # Optional boolean
-      security_log:  # Optional
-        - path: path  # Required
-          destination: dest  # Required
-    grpc_global:  # Optional -- Configure GRPC
-      bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
-        address: $remote_addr  # Required
-        transparent: true  # Optional boolean
-      buffer_size: 4k  # Optional
-      connect_timeout: 60s  # Optional
-      hide_header: []  # Optional list
-      ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
-      intercept_errors: false  # Optional boolean
-      next_upstream: []  # Optional list
-      next_upstream_timeout: 0  # Optional
-      next_upstream_tries: 0  # Optional
-      pass_header: []  # Optional list
-      read_timeout: 60s  # Optional
-      send_timeout: 60s  # Optional
-      set_header:  # Optional
-        - field: Accept-Encoding  # Required
-          value: '""'  # Required
-      socket_keepalive: false  # Optional boolean
-      ssl_certificate: /path/to/file  # Optional
-      ssl_certificate_key: /path/to/file  # Optional
-      ssl_ciphers: DEFAULT  # Optional
-      ssl_conf_command: 'command'  # Optional
-      ssl_crl: /path/to/file  # Optional
-      ssl_name: serverName  # Optional
-      ssl_password_file: /path/to/file  # Optional
-      ssl_protocols: []  # Optional list
-      ssl_server_name: false  # Optional boolean
-      ssl_session_reuse: true  # Optional boolean
-      ssl_trusted_certificate: /path/to/file  # Optional
-      ssl_verify: false  # Optional boolean
-      ssl_verify_depth: 1  # Optional
-    gzip:  # Optional -- Configure GZIP
-      enable: true  # Optional boolean
-      buffers:  # Optional
-        number: 32  # Required
-        size: 4k  # Required
-      comp_level: 1  # Optional
-      disable: []  # Optional list
-      http_version: 1.1  # Optional -- One of '1.0' or '1.1'
-      min_length: 20  # Optional
-      proxied: []  # Optional list
-      types: []  # Optional list
-      vary: false  # Optional boolean
+    # app_protect_global:  # Optional -- Configure NGINX App Protect
+    #   physical_memory_util_thresholds:  # Optional
+    #     high: 100  # Required
+    #     low: 100  # Required
+    #   cpu_thresholds:  # Optional
+    #     high: 100  # Required
+    #     low: 100  # Required
+    #   failure_mode_action: pass  # Optional -- 'pass' or 'drop'
+    #   cookie_seed: encryptionseed  # Optional
+    #   compressed_requests_action: drop  # Optional -- 'pass' or 'drop'
+    #   request_buffer_overflow_action: pass  # Optional -- 'pass' or 'drop'
+    #   user_defined_signatures: []  # Optional list
+    # app_protect:  # Optional -- Configure NGINX App Protect
+    #   enable: false  # Optional boolean
+    #   policy_file: path  # Optional
+    #   security_log_enable: false  # Optional boolean
+    #   security_log:  # Optional
+    #     - path: path  # Required
+    #       dest: dest  # Required
+    # grpc_global:  # Optional -- Configure GRPC
+    #   bind:  # Optional -- Set to 'false' and remove/comment nested variables to disable grpc_bind
+    #     address: $remote_addr  # Required
+    #     transparent: true  # Optional boolean
+    #   buffer_size: 4k  # Optional
+    #   connect_timeout: 60s  # Optional
+    #   hide_header: []  # Optional list
+    #   ignore_headers: []  # Optional list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
+    #   intercept_errors: false  # Optional boolean
+    #   next_upstream: []  # Optional list
+    #   next_upstream_timeout: 0  # Optional
+    #   next_upstream_tries: 0  # Optional
+    #   pass_header: []  # Optional list
+    #   read_timeout: 60s  # Optional
+    #   send_timeout: 60s  # Optional
+    #   set_header:  # Optional
+    #     - field: Accept-Encoding  # Required
+    #       value: '""'  # Required
+    #   socket_keepalive: false  # Optional boolean
+    #   ssl_certificate: /path/to/file  # Optional
+    #   ssl_certificate_key: /path/to/file  # Optional
+    #   ssl_ciphers: DEFAULT  # Optional
+    #   ssl_conf_command: 'command'  # Optional
+    #   ssl_crl: /path/to/file  # Optional
+    #   ssl_name: serverName  # Optional
+    #   ssl_password_file: /path/to/file  # Optional
+    #   ssl_protocols: []  # Optional list
+    #   ssl_server_name: false  # Optional boolean
+    #   ssl_session_reuse: true  # Optional boolean
+    #   ssl_trusted_certificate: /path/to/file  # Optional
+    #   ssl_verify: false  # Optional boolean
+    #   ssl_verify_depth: 1  # Optional
+    # gzip:  # Optional -- Configure GZIP
+    #   enable: true  # Optional boolean
+    #   buffers:  # Optional
+    #     number: 32  # Required
+    #     size: 4k  # Required
+    #   comp_level: 1  # Optional
+    #   disable: []  # Optional list
+    #   http_version: 1.1  # Optional -- One of '1.0' or '1.1'
+    #   min_length: 20  # Optional
+    #   proxied: []  # Optional list
+    #   types: []  # Optional list
+    #   vary: false  # Optional boolean
     access_log_format:
       - name: main
         format: |-
           '$remote_addr - $remote_user [$time_local] "$request" '
-          '$status $body_bytes_sent "$http_referer" '
-          '"$http_user_agent" "$http_x_forwarded_for"'
+                              '$status $body_bytes_sent "$http_referer" '
+                              '"$http_user_agent" "$http_x_forwarded_for"'
     access_log_location:
       - name: main
         location: /var/log/nginx/access.log
     sendfile: true
-    tcp_nopush: true
-    tcp_nodelay: true
+    # tcp_nopush: true
+    # tcp_nodelay: true
     keepalive_timeout: 65
-    cache: false
-    rate_limit: false
-    keyval: false
-    server_tokens: "off"
-    server_names_hash_bucket_size: 64
-    server_names_hash_max_size: 512
-  http_global_autoindex: false
-  sub_filter:
-    # sub_filters: []
-    last_modified: false
-    once: true
-    types: "text/html"
+    # cache: false
+    # rate_limit: false
+    # keyval: false
+    # server_tokens: "off"
+    # server_names_hash_bucket_size: 64
+    # server_names_hash_max_size: 512
+  # http_global_autoindex: false
+  # sub_filter:
+  #   # sub_filters: []
+  #   last_modified: false
+  #   once: true
+  #   types: "text/html"
   # custom_options: []
   # http_custom_options: []
   # http_custom_includes: []
@@ -393,7 +393,7 @@ nginx_config_http_template:
           security_log_enable: false  # Optional
           security_log:  # Optional
             - path: path  # Required
-              destination: dest  # Required
+              dest: dest  # Required
         auth_jwt:  # Optional -- Configure JWT auth
           enable:  # Optional -- Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
             realm: realm  # Required
@@ -615,7 +615,7 @@ nginx_config_http_template:
               security_log_enable: false  # Optional
               security_log:  # Optional
                 - path: path  # Required
-                  destination: dest  # Required
+                  dest: dest  # Required
               auth_jwt:  # Optional -- Configure JWT auth
                 enable:  # Optional -- Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
                   realm: realm  # Required

--- a/templates/http/app_protect.j2
+++ b/templates/http/app_protect.j2
@@ -31,13 +31,13 @@ app_protect_user_defined_signatures {{ signature }};
 {% endmacro %}
 
 {% macro app_protect_local(app_protect) %}
-{% if app_protect['enable'] is defined %}
+{% if app_protect['enable'] is defined and app_protect['enable'] is boolean %}
 app_protect_enable {{ app_protect['enable'] | ternary('on', 'off') }};
 {% endif %}
 {% if app_protect['policy_file'] is defined %}
 app_protect_policy_file {{ app_protect['policy_file'] }};
 {% endif %}
-{% if app_protect['security_log_enable'] is defined %}
+{% if app_protect['security_log_enable'] is defined and app_protect['security_log_enable'] is boolean %}
 app_protect_security_log_enable {{ app_protect['security_log_enable'] | ternary('on', 'off') }};
 {% endif %}
 {% if app_protect['security_log'] is defined %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -23,7 +23,7 @@ worker_rlimit_nofile {{ nginx_config_main_template.worker_rlimit_nofile }};
 {% endif %}
 
 {% if nginx_config_main_template.error_log is defined %}
-error_log  {{ nginx_config_main_template.error_log.location }} {{ nginx_config_main_template.error_log.level }};
+error_log {{ nginx_config_main_template.error_log.location }} {{ nginx_config_main_template.error_log.level }};
 {% endif %}
 {% if nginx_config_main_template.pid is defined %}
 pid {{ nginx_config_main_template.pid }};
@@ -31,7 +31,7 @@ pid {{ nginx_config_main_template.pid }};
 
 events {
 {% if nginx_config_main_template.worker_connections is defined %}
-    worker_connections  {{ nginx_config_main_template.worker_connections }};
+    worker_connections {{ nginx_config_main_template.worker_connections }};
 {% endif %}
 {% if nginx_config_main_template.events_custom_options is defined and nginx_config_main_template.events_custom_options | length %}
 {% for inline_option in nginx_config_main_template.events_custom_options %}
@@ -42,8 +42,8 @@ events {
 
 {% if nginx_config_main_template.http_enable is defined and nginx_config_main_template.http_enable %}
 http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 {% if nginx_config_main_template.http_settings.app_protect_global is defined %}
 {% from 'http/app_protect.j2' import app_protect_global with context %}
 {% filter indent(4) %}
@@ -70,7 +70,7 @@ http {
 {% endif %}
 {% if nginx_config_main_template.http_settings.access_log_format is defined %}
 {% for access_log in nginx_config_main_template.http_settings.access_log_format %}
-    log_format  {{ access_log.name }}  {{ access_log.format }};
+    log_format {{ access_log.name }} {{ access_log.format }};
 {% endfor %}
 {% endif %}
 {% if nginx_config_main_template.http_settings.access_log_location is defined %}
@@ -78,24 +78,24 @@ http {
     access_log off;
 {% else %}
 {% for access_log in nginx_config_main_template.http_settings.access_log_location %}
-    access_log  {{ access_log.location }}  {{ access_log.name }};
+    access_log {{ access_log.location }} {{ access_log.name }};
 {% endfor %}
 {% endif %}
 {% endif %}
 {% if nginx_config_main_template.http_settings.sendfile is defined and nginx_config_main_template.http_settings.sendfile %}
-    sendfile        on;
+    sendfile on;
 {% endif %}
 {% if nginx_config_main_template.http_settings.tcp_nopush is defined and nginx_config_main_template.http_settings.tcp_nopush %}
-    tcp_nopush      on;
+    tcp_nopush on;
 {% endif %}
 {% if nginx_config_main_template.http_settings.tcp_nodelay is defined and nginx_config_main_template.http_settings.tcp_nodelay %}
-    tcp_nodelay     on;
+    tcp_nodelay on;
 {% endif %}
 {% if nginx_config_main_template.http_settings.server_tokens is defined and nginx_config_main_template.http_settings.server_tokens | length %}
     server_tokens {{ nginx_config_main_template.http_settings.server_tokens }};
 {% endif %}
 {% if nginx_config_main_template.http_settings.keepalive_timeout is defined %}
-    keepalive_timeout  {{ nginx_config_main_template.http_settings.keepalive_timeout }};
+    keepalive_timeout {{ nginx_config_main_template.http_settings.keepalive_timeout }};
 {% endif %}
 {% if nginx_config_main_template.http_settings.rate_limit is defined %}
     limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
@@ -105,10 +105,10 @@ http {
     keyval $arg_text $text zone=one;
 {% endif %}
 {% if nginx_config_main_template.http_settings.server_names_hash_bucket_size is defined %}
-    server_names_hash_bucket_size  {{ nginx_config_main_template.http_settings.server_names_hash_bucket_size }};
+    server_names_hash_bucket_size {{ nginx_config_main_template.http_settings.server_names_hash_bucket_size }};
 {% endif %}
 {% if nginx_config_main_template.http_settings.server_names_hash_max_size is defined %}
-    server_names_hash_max_size  {{ nginx_config_main_template.http_settings.server_names_hash_max_size }};
+    server_names_hash_max_size {{ nginx_config_main_template.http_settings.server_names_hash_max_size }};
 {% endif %}
 {% if nginx_config_main_template.http_global_autoindex is defined | default(false) %}
     autoindex on;
@@ -119,7 +119,7 @@ http {
 {% endfor %}
 {% endif %}
 {% if nginx_config_main_template.sub_filter.last_modified is defined %}
-    sub_filter_last_modified  {{ nginx_config_main_template.sub_filter.last_modified | ternary("on", "off") }};
+    sub_filter_last_modified {{ nginx_config_main_template.sub_filter.last_modified | ternary("on", "off") }};
 {% endif %}
 {% if nginx_config_main_template.sub_filter.once is defined %}
     sub_filter_once {{ nginx_config_main_template.sub_filter.once | ternary("on", "off") }};


### PR DESCRIPTION
### Proposed changes
Ensure the default values for the `nginx.conf` template match the default values found on a fresh NGINX installation. As well as fix an issue with the `app_protect.j2` template that was causing the default values for `nginx.conf` to fail. Fixes #147.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
