### PR TITLE
Replace Jinja2 sequence checks with mapping (dictionary) checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2 (Unreleased)
+
+BUG FIXES:
+
+Dictionaries are a sequence per Jinja2 contrary to Python's defaults (dictionaries are not a sequence in Python). The template conditionals assumed the latter.
+
 ## 0.4.1 (October 25, 2021)
 
 BUG FIXES:

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -16,7 +16,7 @@ nginx_config_main_template:
   deployment_location: /etc/nginx/nginx.conf
   config:
     main:  # Configure NGINX main core directives
-      load_module: modules/ngx_http_js_module.so  # Can be a string or a list
+      load_module: modules/ngx_http_js_module.so  # String or a list
         # - modules/ngx_http_js_module.so
       user:  # nginx  # Can alternatively be a 'user' string
         username: nginx  # Required
@@ -29,7 +29,7 @@ nginx_config_main_template:
       # worker_rlimit_core: 1m
       # worker_rlimit_nofile: 10000  # Number
       # worker_shutdown_timeout: 30m
-      error_log:  # /var/log/nginx/error.log  # Can be a string, a dictionary, or a list of dictionaries. The 'file' variable is only required when setting a 'level'.
+      error_log:  # /var/log/nginx/error.log  # String, a dictionary, or a list of dictionaries. The 'file' variable is only required when setting a 'level'.
         file: /var/log/nginx/error.log  # Required
         level: notice
         # - /var/log/nginx/error.log
@@ -38,7 +38,7 @@ nginx_config_main_template:
       pid: /var/run/nginx.pid
       daemon: true  # Boolean
       # debug_points: abort  # Can be 'abort' or 'stop'
-      # env:  # MALLOC_OPTIONS  # Can be a string, a dictionary, or a list of dictionaries. The 'variable' variable is only required when setting a 'value'.
+      # env:  # MALLOC_OPTIONS  # String, a dictionary, or a list of dictionaries. The 'variable' variable is only required when setting a 'value'.
       #   variable: PERL5LIB  # Required
       #   value: /data/site/modules
       #   - MALLOC_OPTIONS
@@ -48,7 +48,7 @@ nginx_config_main_template:
       # master_process: true  # Boolean
       # pcre_jit: false  # Boolean
       # ssl_engine: device
-      # thread_pool:  # Can be a dictionary or a list of dictionaries.
+      # thread_pool:  # Dictionary or a list of dictionaries
       #   - name: default  # Required
       #     threads: 32  # Required boolean
       #     max_queue: 65536  # Boolean
@@ -57,17 +57,17 @@ nginx_config_main_template:
     events:  # Configure NGINX events
       # accept_mutex: false  # Boolean
       # accept_mutex_delay: 500ms
-      # debug_connection:  # localhost  # Can be a string or a list
+      # debug_connection:  # localhost  # String or a list
       #   - localhost
       # multi_accept: false  # Boolean
       # use: epoll
       # worker_aio_requests: 32  # Number
       worker_connections: 1024  # Number
     http:
-      include: /etc/nginx/conf.d/*.conf  # Can be a string or a list
+      include: /etc/nginx/conf.d/*.conf  # String or a list
         # - /etc/nginx/conf.d/*.conf
     stream:
-      include: /etc/nginx/conf.d/stream/*.conf  # Can be a string or a list
+      include: /etc/nginx/conf.d/stream/*.conf  # String or a list
         # - /etc/nginx/conf.d/stream/*.conf
 
 # Enable creating dynamic templated NGINX HTTP configuration files.
@@ -119,7 +119,7 @@ nginx_config_http_template:
           keepalive_timeout: 60s
           ntlm: false  # Available only in NGINX Plus -- Boolean
           resolver:  # Available only in NGINX Plus
-            address: []  # Required -- Can be a string or a list
+            address: []  # Required -- String or a list
             valid: 30s
             ipv6: false  # Boolean
             status_zone: backend_mem_zone
@@ -132,10 +132,10 @@ nginx_config_http_template:
             samesite: none  # Note -- Must be one of 'strict', 'lax' or 'none'
             secure: true  # Boolean
             path: path
-          sticky_route: []  # Can be a string or a list
+          sticky_route: []  # String or a list
           sticky_learn:  # Available only in NGINX Plus
-            create: []  # Required -- Can be a string or a list
-            lookup: []  # Required -- Can be a string or a list
+            create: []  # Required -- String or a list
+            lookup: []  # Required -- String or a list
             zone:  # Required
               name: client_sessions  # Required
               size: 1m  # Required
@@ -167,8 +167,8 @@ nginx_config_http_template:
         disable_symlinks:  # Can be directly set to 'true', 'false' or 'if_not_owner'. A dictionary is required if you want to set 'from'.
           check: 'on'  # Required  -- Can be set to 'on' or 'if_not_owner'
           from: $document_root
-        error_page:
-          - code:  # Required number -- Can be a number or a list of numbers
+        error_page:  # Dictionary or a list of dictionaries
+          - code:  # Required number -- Number or a list of numbers
               - 404
             response: 404
             uri: /404.html  # Required
@@ -178,10 +178,10 @@ nginx_config_http_template:
         include: path  # Note -- This directive originally belongs in the NGINX core module, but we are making an exception here
         index: path  # Note -- This directive originally belongs in the NGINX index module, but we are making an exception here
         internal: false  # Boolean -- Only available in the 'location' context
-        keepalive_disable: msie6  # Can be a string or a list
+        keepalive_disable: msie6  # String or a list
         keepalive_requests: 1000  # Number
         keepalive_time: 1h
-        keepalive_timeout:  # Can be a string or a dictionary. The latter is required to set 'header_timeout'
+        keepalive_timeout:  # String or a dictionary. The latter is required to set 'header_timeout'.
           timeout: 75s  # Required
           header_timeout: 75s
         large_client_header_buffers:
@@ -189,7 +189,7 @@ nginx_config_http_template:
           size: 8k  # Required
         limit_except:  # Available only in 'location' context
           method: GET  # Required -- Can be a string or a list
-          directive:  # Can be a string or a list
+          directive:  # String or a list
             - allow all
         limit_rate: 0
         limit_rate_after: 0
@@ -238,7 +238,7 @@ nginx_config_http_template:
         request_pool_size: 4k
         reset_timedout_connection: false  # Boolean
         resolver:
-          address: 127.0.0.1  # Required -- Can also be a list
+          address: 127.0.0.1  # Required -- String or a list
           valid: 60s
           ipv6: false  # Boolean
           status_zone: zone  # Only available in NGINX Plus
@@ -260,14 +260,14 @@ nginx_config_http_template:
         tcp_nodelay: true  # Boolean
         tcp_nopush: false  # Boolean
         try_files:
-          files: $uri  # Required - Can be a string or a list
+          files: $uri  # Required - String or a list
             # - $uri1
             # - $uri2
           uri: /uri  # Must set either the 'uri' or 'code' parameter
           code: code  # Must set either the 'uri' or 'code' parameter
-        types:
+        types:  # Dictionary or list of dictionaries
           - mime: text/html  # Required
-            extensions: html  # Required -- Can be a string or a list
+            extensions: html  # Required -- String or a list
               # - html
               # - htm
         types_hash_bucket_size: 64
@@ -277,19 +277,19 @@ nginx_config_http_template:
         variables_hash_max_size: 1024  # Only allowed in 'http' context
       ssl:
         buffer_size: 16k
-        certificate: /path/to/file  # String or list
-        certificate_key: /path/to/file  # String or list
-        ciphers: HIGH  # String or list
+        certificate: /path/to/file  # String or a list
+        certificate_key: /path/to/file  # String or a list
+        ciphers: HIGH  # String or a list
           # - HIGH
           # - "!aNull"
           # - "!MD5"
         client_certificate: /path/to/file
-        conf_command: 'command'  #  String or list
+        conf_command: 'command'  #  String or a list
           # - 'command'
         crl: /path/to/file
         dhparam: /path/to/file
         early_data: false  # Boolean
-        ecdh_curve: auto  # String or list
+        ecdh_curve: auto  # String or a list
           # - prime256v1
         ocsp: false  # Boolean or 'leaf'
         ocsp_cache: false  # Can be set to 'false' or use the 'name'/'size' dict to create a shared cache
@@ -298,7 +298,7 @@ nginx_config_http_template:
         ocsp_responder: <url>
         password_file: /path/to/file
         prefer_server_ciphers: false  # Boolean
-        protocols: TLSv1  # String or list
+        protocols: TLSv1  # String or a list
           # - TLSv1
           # - TLSv1.1
           # - TLSv1.2
@@ -310,7 +310,7 @@ nginx_config_http_template:
           # shared:
           #   name: cache  # Required
           #   size: 16k  # Required
-        session_ticket_key: /path/to/file  # String or list
+        session_ticket_key: /path/to/file  # String or a list
         session_tickets: true  # Boolean
         session_timeout: 5m
         stapling: false  # Boolean
@@ -318,7 +318,7 @@ nginx_config_http_template:
         stapling_responder: <url>
         stapling_verify: false  # Boolean
         trusted_certificate: /path/to/file
-        verify_client: false  # Boolean, 'optional' or 'optional_no_ca'
+        verify_client: false  # Boolean -- 'optional' or 'optional_no_ca'
         verify_depth: 1  # Number
       app_protect_waf:  # Only available when using NGINX App Protect WAF -- Configure NGINX App Protect WAF
         physical_memory_util_thresholds:
@@ -332,13 +332,13 @@ nginx_config_http_template:
         compressed_requests_action: drop  # Can be set to 'pass' or 'drop'
         reconnect_period_seconds: 5  # Number
         request_buffer_overflow_action: pass  # Can be set to 'pass' or 'drop'
-        user_defined_signatures: /path/to/file  # String or list
+        user_defined_signatures: /path/to/file  # String or a list
           # - /path/to/file1
           # - /path/to/file2
         enable: false  # Boolean
         policy_file: /path/to/file
         security_log_enable: false  # Boolean
-        security_log:  # Can be a dictionary or a list of dictionaries
+        security_log:  # Dictionary or a list of dictionaries
           - path: /path/to/file  # Required
             dest: dest  # Required
       app_protect_dos:  # Only available when using NGINX App Protect DoS -- Configure NGINX App Protect DoS
@@ -404,18 +404,19 @@ nginx_config_http_template:
             purger_files: 10  # Number
             purger_sleep: 50ms
             purger_threshold: 50ms
-        cache_purge: sample  # String or list
+        cache_purge: sample  # String or a list
           # - cache_key
           # - cache_purge
         cache_revalidate: false  # Boolean
-        cache_use_stale: false  # String or list -- set to 'false' to set to 'off'
+        cache_use_stale: false  # String or a list -- set to 'false' to set to 'off'
           # - error
           # - timeout
-        cache_valid:  # 10m  # String, dictionary or list of dictionaries. 'time' is required when using 'code'.
+        cache_valid:  # 10m  # String, dictionary or a list of dictionaries. 'time' variable is required when using 'code'.
           - code: 200  # String or list
             # - 201
             # - 202
             time: 10m  # Required
+          - 2m  # Alternative way to specify time
         connect_timeout: 60s
         cookie_domain: false  # Set to 'false' and remove/comment nested variables to disable proxy_cookie_domain. Variables can be a dictionary or list of dictionaries.
           # - domain: localhost  # Required
@@ -430,18 +431,18 @@ nginx_config_http_template:
         force_ranges: false  #  Boolean
         headers_hash_bucket_size: 64
         headers_hash_max_size: 512
-        hide_header: Date  # String or list
+        hide_header: Date  # String or a list
           # - Date
           # - X-Accel-Redirect
         http_version: 1.1  # Can be 1.0 or 1.1
         ignore_client_abort: false  # Boolean
-        ignore_headers: X-Accel-Redirect  # String or list -- can be one of 'X-Accel-Redirect', 'X-Accel-Expires', 'X-Accel-Limit-Rate', 'X-Accel-Buffering', 'X-Accel-Charset', 'Expires', 'Cache-Control', 'Set-Cookie' or 'Vary'.
+        ignore_headers: X-Accel-Redirect  # String or a list -- can be one of 'X-Accel-Redirect', 'X-Accel-Expires', 'X-Accel-Limit-Rate', 'X-Accel-Buffering', 'X-Accel-Charset', 'Expires', 'Cache-Control', 'Set-Cookie' or 'Vary'.
           # - X-Accel-Redirect
         intercept_errors: false  # Boolean
         limit_rate: 0
         max_temp_file_size: 1024m
         method: GET
-        next_upstream: false  # Set to 'false' to disable proxy_next_upstream or include a variable string or list
+        next_upstream: false  # String or a list -- set to 'false' to set to 'off'
           # - error
           # - timeout
         next_upstream_timeout: 0
@@ -451,7 +452,7 @@ nginx_config_http_template:
           #   - $arg_nocache$arg_comment
           # - $arg_nocache$arg_comment
         pass: http://127.0.0.1
-        pass_header: Date  # String or list
+        pass_header: Date  # String or a list
           # - Date
           # - X-Accel-Redirect
         pass_request_body: false  # Boolean
@@ -467,7 +468,7 @@ nginx_config_http_template:
         send_lowat: 0
         send_timeout: 60s
         set_body: body
-        set_header:  # Dictionary or list of dictionaries
+        set_header:  # Dictionary or a list of dictionaries
           field: Host
           value: $proxy_host
           # - field: Connection
@@ -475,14 +476,14 @@ nginx_config_http_template:
         socket_keepalive: false  # Boolean
         ssl_certificate: /path/to/file
         ssl_certificate_key: /path/to/file
-        ssl_ciphers: DEFAULT  # String or list
+        ssl_ciphers: DEFAULT  # String or a list
           # - DEFAULT
-        ssl_conf_command: 'command'  # String or list
+        ssl_conf_command: 'command'  # String or a list
           # - 'command'
         ssl_crl: /path/to/file
         ssl_name: $proxy_host
         ssl_password_file: /path/to/file
-        ssl_protocols: TLSv1  # String or list
+        ssl_protocols: TLSv1  # String or a list
           # - TLSv1
           # - TLSv1.1
           # - TLSv1.2
@@ -506,36 +507,36 @@ nginx_config_http_template:
           transparent: true  # Boolean
         buffer_size: 4k
         connect_timeout: 60s
-        hide_header: []  # string or list
-        ignore_headers: []  # string or list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
+        hide_header: []  # String or a list
+        ignore_headers: []  # String or a list -- 'X-Accel-Redirect' or 'X-Accel-Charset'
         intercept_errors: false  # Boolean
-        next_upstream: []  # string list
+        next_upstream: []  # String or a list
         next_upstream_timeout: 0
         next_upstream_tries: 0
         pass: uri
-        pass_header: []  # string or list
+        pass_header: []  # String or a list
         read_timeout: 60s
         send_timeout: 60s
-        set_header:  # Can be a dictionary or a list of dictionaries
+        set_header:  # Dictionary or a list of dictionaries
           - field: Accept-Encoding  # Required
             value: '""'  # Required
         socket_keepalive: false  # Boolean
         ssl_certificate: /path/to/file
         ssl_certificate_key: /path/to/file
         ssl_ciphers: DEFAULT
-        ssl_conf_command: 'command'  # Can be a string or a list
+        ssl_conf_command: 'command'  # String or a list
         ssl_crl: /path/to/file
         ssl_name: serverName
         ssl_password_file: /path/to/file
-        ssl_protocols: []  # String or list
+        ssl_protocols: []  # String or a list
         ssl_server_name: false  # Boolean
         ssl_session_reuse: true  # Boolean
         ssl_trusted_certificate: /path/to/file
         ssl_verify: false  # Boolean
         ssl_verify_depth: 1
       access:  # Configure HTTP access
-        allow: localhost  # Can be string or list
-        deny: 192.168.1.100  # Can be string or list
+        allow: localhost  # String or a list
+        deny: 192.168.1.100  # String or a list
       auth_basic:  # Configure basic auth
         realm: false  # Set to 'false' to set auth_basic to 'off' -- otherwise, you can specify a 'realm'
         user_file: /path/to/file
@@ -548,18 +549,18 @@ nginx_config_http_template:
         enable:  #  Set to 'false' and remove/comment nested variables to set auth_jwt to 'off'
           realm: realm  # Required
           token: $cookie_auth_token
-        claim_set:  # Can be a dictionary or a list of dictionaries
+        claim_set:  # Dictionary or a list of dictionaries
           - variable: $email  # Required
-            name:  # Required string or list
+            name:  # Required -- String or a list
               - info
-        header_set:  # Can be a dictionary or a list of dictionaries
+        header_set:  # Dictionary or a list of dictionaries
           - variable: $job  # Required
-            name: info  # Required string or list
+            name: info  # Required -- String or a list
         key_file: /path/to/file
         key_request: /path/to/file
         leeway: 0s
         type: signed  # One of 'signed', 'encrypted' or 'nested'
-        required: $valid_jwt_iss  # String or list
+        require: $valid_jwt_iss  # String or a list
       api:  # Configure NGINX Plus HTTP API
         enable:  # true  # Set to Boolean directly to simply enable the 'api' directive
           write: true  # Boolean
@@ -576,11 +577,11 @@ nginx_config_http_template:
           number: 32  # Required
           size: 4k  # Required
         comp_level: 1
-        disable: []  # String or list
+        disable: []  # String or a list
         http_version: 1.1  # Optional -- One of '1.0' or '1.1'
         min_length: 20
         proxied: []  # Set to 'false' to set to 'off' -- otherwise, you can specify a string or a list
-        types: []  # String or list
+        types: []  # String or a list
         vary: false  # Boolean
       headers:  # Configure headers
         add_headers:  # Can be a dictionary or a list of dictionaries
@@ -609,7 +610,7 @@ nginx_config_http_template:
             grpc_status: 12
         match:  # Optional list
           - name: name  # Required
-            conditions: []  # list
+            conditions: []  # Optional list
               # - status 200
       keyval:  # Available only in NGINX Plus -- Configure NGINX Plus key value store
         keyvals:
@@ -652,13 +653,13 @@ nginx_config_http_template:
             gzip: 5  # Can also be set to 'true'
             flush: 10h
             if: $loggable
-        error:  # /var/log/nginx/error.log  # Can be a string, a dictionary, or a list. The 'file' variable is only required when setting a 'level'. This directive does not belong in this module but we are making an exception.
+        error:  # /var/log/nginx/error.log  # String, dictionary, or list. The 'file' variable is only required when setting a 'level'. This directive does not belong in this module but we are making an exception.
           file: /var/log/nginx/error.log  # Required
           level: notice
           # - /var/log/nginx/error.log
           # - file: /var/log/nginx/error.log  # Required
           #   level: notice
-        open_log_file_cache:  # Can also be set to 'false' to set to 'off'
+        open_log_file_cache:  # Set to 'false' to set to 'off'
           max: 1000  # Required
           inactive: 20s
           min_uses: 2  # Number
@@ -673,17 +674,17 @@ nginx_config_http_template:
             replacement: $1$2  # Required
             flag: last  # Can be 'last', 'break', 'redirect' or 'permanent'
         log: false  # Boolean
-        set:  # Can be a dictionary or a list of dictionaries
+        set:  # Dictionary or a list of dictionaries
           - variable: $var  # Required
             value: var  # Required
         uninitialized_variable_warn: true  # Boolean
       sub_filter:  # Configure sub filter directives
-        sub_filters:  # Can be a dictionary or a list of dictionaries
+        sub_filters:  # Dictionary or a list of dictionaries
           - string: server_hostname  # Required
             replacement: $hostname  # Required
         last_modified: false  # Boolean
         once: true  # Boolean
-        types: text/html  # String or list
+        types: text/html  # String or a list
       custom_directives:  # Custom directive for specific use cases not covered by templates -- you need to add a semi-colon at the end of each directive
         - fastcgi_split_path_info ^(.+\.php)(/.+)$;
         - fastcgi_pass unix:/run/php/php7.2-fpm.sock;

--- a/molecule/common/requirements/oss_requirements.yml
+++ b/molecule/common/requirements/oss_requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.21.2
+    version: 0.21.3

--- a/molecule/common/requirements/plus_requirements.yml
+++ b/molecule/common/requirements/plus_requirements.yml
@@ -1,6 +1,6 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.21.2
+    version: 0.21.3
   - name: nginxinc.nginx_app_protect
-    version: 0.6.1
+    version: 0.6.2

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -46,9 +46,8 @@
               daemon: true
               debug_points: abort
               env:
-                - variable: MALLOC_OPTIONS
-                - variable: PERL5LIB
-                  value: /data/site/modules
+                variable: PERL5LIB
+                value: /data/site/modules
               lock_file: logs/nginx.lock
               master_process: true
               pcre_jit: false
@@ -306,8 +305,10 @@
                 cookie_domain:
                   - domain: localhost
                     replacement: example.com
-                cookie_flags: false  # -- set to false
-                cookie_path: false
+                cookie_flags: false
+                cookie_path:
+                  path: $uri
+                  replacement: $uri
                 force_ranges: false
                 headers_hash_bucket_size: 64
                 headers_hash_max_size: 512
@@ -346,6 +347,17 @@
                   - field: Connection
                     value: close
                 socket_keepalive: false
+                ssl_certificate: /etc/ssl/certs/molecule.crt
+                ssl_certificate_key: /etc/ssl/private/molecule.key
+                ssl_ciphers: HIGH
+                ssl_conf_command:
+                  - Protocol TLSv1.2
+                ssl_name: $proxy_host
+                ssl_protocols: TLSv1.2
+                ssl_server_name: false
+                ssl_session_reuse: true
+                ssl_verify: false
+                ssl_verify_depth: 1
                 store: false
                 store_access:
                   user: rw
@@ -361,23 +373,29 @@
                   transparent: false
                 buffer_size: 4k
                 connect_timeout: 60s
-                hide_header:
-                  - X-Accel-Redirect
-                ignore_headers:
-                  - X-Accel-Redirect
+                hide_header: X-Accel-Redirect
+                ignore_headers: X-Accel-Redirect
                 intercept_errors: false
-                next_upstream:
-                  - timeout
+                next_upstream: timeout
                 next_upstream_timeout: 0
                 next_upstream_tries: 0
-                pass_header:
-                  - X-Accel-Charset
+                pass_header: X-Accel-Charset
                 read_timeout: 60s
                 send_timeout: 60s
                 set_header:
-                  - field: Accept-Encoding
-                    value: '""'
+                  field: Accept-Encoding
+                  value: '""'
                 socket_keepalive: false
+                ssl_certificate: /etc/ssl/certs/molecule.crt
+                ssl_certificate_key: /etc/ssl/private/molecule.key
+                ssl_ciphers: HIGH
+                ssl_conf_command: Protocol TLSv1.2
+                ssl_name: $proxy_host
+                ssl_protocols: TLSv1.2
+                ssl_server_name: false
+                ssl_session_reuse: true
+                ssl_verify: false
+                ssl_verify_depth: 1
               access:
                 allow:
                   - all
@@ -416,9 +434,9 @@
                     value: '"max-age=15768000; includeSubDomains"'
                     always: true
                 add_trailers:
-                  - name: Strict-Transport-Security
-                    value: '"max-age=15768000; includeSubDomains"'
-                    always: false
+                  name: Strict-Transport-Security
+                  value: '"max-age=15768000; includeSubDomains"'
+                  always: false
                 expires:
                   modified: true
                   time: "12h"

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -203,8 +203,8 @@
                     name:
                       - info
                 header_set:
-                  - variable: $job
-                    name: info
+                  variable: $job
+                  name: info
                 leeway: 0s
                 type: nested
                 require: jwt

--- a/templates/core.j2
+++ b/templates/core.j2
@@ -2,7 +2,7 @@
 
 {# NGINX Core template -- ngx_core_module #}
 {% macro main(main) %}
-{% if main['load_module'] is defined and main['load_module'] is sequence %}
+{% if main['load_module'] is defined and main['load_module'] is not mapping %}
 {% for module in main['load_module'] if main['load_module'] is not string %}
 load_module {{ module }};
 {% else %}
@@ -34,7 +34,7 @@ worker_shutdown_timeout {{ main['worker_shutdown_timeout'] }};
 {% endif %}
 
 {% if main['error_log'] is defined %}
-{% for log in main['error_log'] if (main['error_log'] is sequence and main['error_log'] is not string) %}
+{% for log in main['error_log'] if (main['error_log'] is not mapping and main['error_log'] is not string) %}
 error_log {{ log if log is string else log['file'] }}{{ (' ' + log['level'] | string) if log['level'] is defined }};
 {% else %}
 error_log {{ main['error_log'] if main['error_log'] is string else main['error_log']['file'] }}{{ (' ' + main['error_log']['level'] | string) if main['error_log']['level'] is defined }};
@@ -52,7 +52,7 @@ debug_points {{ main['debug_points'] }};
 {% endif %}
 
 {% if main['env'] is defined %}
-{% for env in main['env'] if (main['env'] is sequence and main['env'] is not string) %}
+{% for env in main['env'] if (main['env'] is not mapping and main['env'] is not string) %}
 env {{ env if env is string else env['variable'] }}{{ ('=' + env['value'] | string) if env['value'] is defined }};
 {% else %}
 env {{ main['env'] if main['env'] is string else main['env']['variable'] }}{{ ('=' + main['env']['value'] | string) if main['env']['value'] is defined }};
@@ -70,9 +70,11 @@ pcre_jit {{ main['pcre_jit'] | ternary('on', 'off') }};
 {% if main['ssl_engine'] is defined %}
 ssl_engine {{ main['ssl_engine'] }};
 {% endif %}
-{% if main['thread_pool'] is defined %}
-{% for thread in main['thread_pool'] %}
+{% if main['thread_pool'] is defined and main['thread_pool'] is not string %}
+{% for thread in main['thread_pool'] if main['thread_pool'] is not mapping %}
 thread_pool {{ thread['name'] }} {{ ('threads=' + thread['threads'] | string) if thread['threads'] is number }}{{ (' max_queue=' + thread['max_queue'] | string) if thread['max_queue'] is defined and thread['max_queue'] is number }};
+{% else %}
+thread_pool {{ main['thread_pool']['name'] }} {{ ('threads=' + main['thread_pool']['threads'] | string) if main['thread_pool']['threads'] is number }}{{ (' max_queue=' + main['thread_pool']['max_queue'] | string) if main['thread_pool']['max_queue'] is defined and main['thread_pool']['max_queue'] is number }};
 {% endfor %}
 {% endif %}
 {% if main['timer_resolution'] is defined %}
@@ -90,7 +92,7 @@ accept_mutex {{ events['accept_mutex'] | ternary('on', 'off') }};
 {% if events['accept_mutex_delay'] is defined %}
 accept_mutex_delay {{ events['accept_mutex_delay'] }};
 {% endif %}
-{% if events['debug_connection'] is defined and events['debug_connection'] is sequence %}
+{% if events['debug_connection'] is defined and events['debug_connection'] is not mapping %}
 {% for connection in events['debug_connection'] if events['debug_connection'] is not string %}
 debug_connection {{ connection }};
 {% else %}

--- a/templates/http/app_protect.j2
+++ b/templates/http/app_protect.j2
@@ -11,8 +11,8 @@ app_protect_policy_file {{ app_protect_waf['policy_file'] }};
 {% if app_protect_waf['security_log_enable'] is defined and app_protect_waf['security_log_enable'] is boolean %}
 app_protect_security_log_enable {{ app_protect_waf['security_log_enable'] | ternary('on', 'off') }};
 {% endif %}
-{% if app_protect_waf['security_log'] is defined %}
-{% for security_log in app_protect_waf['security_log'] if (app_protect_waf['security_log'] is sequence and app_protect_waf['security_log'] is not string) %}
+{% if app_protect_waf['security_log'] is defined and app_protect_waf['security_log'] is not string %}
+{% for security_log in app_protect_waf['security_log'] if app_protect_waf['security_log'] is not mapping %}
 app_protect_security_log {{ security_log['path'] }} {{ security_log['dest'] }};
 {% else %}
 app_protect_security_log {{ app_protect_waf['security_log']['path'] }} {{ app_protect_waf['security_log']['dest'] }};
@@ -39,7 +39,7 @@ app_protect_reconnect_period_seconds {{ app_protect_waf['reconnect_period_second
 {% if app_protect_waf['request_buffer_overflow_action'] is defined and app_protect_waf['request_buffer_overflow_action'] in ['pass', 'drop'] %}{# Available only in 'http' context #}
 app_protect_request_buffer_overflow_action {{ app_protect_waf['request_buffer_overflow_action'] }};
 {% endif %}
-{% if app_protect_waf['user_defined_signatures'] is defined and app_protect_waf['user_defined_signatures'] is sequence %}{# Available only in 'http' context #}
+{% if app_protect_waf['user_defined_signatures'] is defined and app_protect_waf['user_defined_signatures'] is not mapping %}{# Available only in 'http' context #}
 {% for signature in app_protect_waf['user_defined_signatures'] if app_protect_waf['user_defined_signatures'] is not string %}
 app_protect_user_defined_signatures {{ signature }};
 {% else %}
@@ -62,7 +62,7 @@ app_protect_dos_name {{ app_protect_dos['name'] }};
 {% endif %}
 {% if app_protect_dos['monitor'] is defined and app_protect_dos['monitor'] is mapping %}
 app_protect_dos_monitor uri={{ app_protect_dos['monitor']['uri'] | ternary(app_protect_dos['monitor']['uri'], app_protect_dos['monitor']) }}{{ app_protect_dos['monitor']['protocol'] | ternary((' protocol=' + app_protect_dos['monitor']['protocol'] | string), '') }}{{ app_protect_dos['monitor']['timeout'] | ternary((' timeout=' + app_protect_dos['monitor']['timeout'] | string), '') }};
-{% elif app_protect_dos['monitor'] is defined %}
+{% elif app_protect_dos['monitor'] is defined and app_protect_dos['monitor'] is string %}
 app_protect_dos_monitor {{ app_protect_dos['monitor'] }};
 {% endif %}
 {% if app_protect_dos['security_log_enable'] is defined and app_protect_dos['security_log_enable'] is boolean %}

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -3,14 +3,14 @@
 
 {# NGINX HTTP Access -- ngx_http_access_module #}
 {% macro access(access) %}
-{% if access['allow'] is defined and access['allow'] is sequence %}
+{% if access['allow'] is defined and access['allow'] is not mapping %}
 {% for allow in access['allow'] if access['allow'] is not string %}
 allow {{ allow }};
 {% else %}
 allow {{ access['allow'] }};
 {% endfor %}
 {% endif %}
-{% if access['deny'] is defined and access['deny'] is sequence %}
+{% if access['deny'] is defined and access['deny'] is not mapping %}
 {% for deny in access['deny'] if access['deny'] is not string %}
 deny {{ deny }};
 {% else %}
@@ -48,14 +48,14 @@ auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['v
 auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined }}{{ (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
 {% endif %}
 {% if auth_jwt['claim_set'] is defined %}{# 'claim_set' is only available in the 'http' context #}
-{% for claim in auth_jwt['claim_set'] if (auth_jwt['claim_set'] is sequence and auth_jwt['claim_set'] is not string) %}
+{% for claim in auth_jwt['claim_set'] if (auth_jwt['claim_set'] is not mapping and auth_jwt['claim_set'] is not string) %}
 auth_jwt_claim_set {{ claim['variable'] }} {{ (claim['name'] if claim['name'] is string else claim['name'] | join(' ')) }};
 {% else %}
 auth_jwt_claim_set {{ auth_jwt['claim_set']['variable'] }} {{ (auth_jwt['claim_set']['name'] if auth_jwt['claim_set']['name'] is string else auth_jwt['claim_set']['name'] | join(' ')) }};
 {% endfor %}
 {% endif %}
 {% if auth_jwt['header_set'] is defined %}{# 'header_set' is only available in the 'http' context #}
-{% for claim in auth_jwt['header_set'] if (auth_jwt['header_set'] is sequence and auth_jwt['header_set'] is not string) %}
+{% for claim in auth_jwt['header_set'] if (auth_jwt['header_set'] is not mapping and auth_jwt['header_set'] is not string) %}
 auth_jwt_header_set {{ claim['variable'] }} {{ (claim['name'] if claim['name'] is string else claim['name'] | join(' ')) }};
 {% else %}
 auth_jwt_header_set {{ auth_jwt['header_set']['variable'] }} {{ (auth_jwt['header_set']['name'] if auth_jwt['header_set']['name'] is string else auth_jwt['header_set']['name'] | join(' ')) }};

--- a/templates/http/core.j2
+++ b/templates/http/core.j2
@@ -65,11 +65,15 @@ directio_alignment {{ core['directio_alignment'] }};
 disable_symlinks {{ (core['disable_symlinks'] | ternary('on', 'off')) if core['disable_symlinks'] is boolean else 'if_not_owner' if core['disable_symlinks'] == 'if_not_owner' -}}
                  {{- core['disable_symlinks']['check'] if core['disable_symlinks']['check'] is defined and core['disable_symlinks']['check'] in ['on', 'if_not_owner'] }}{{ (' from=' + core['disable_symlinks']['from']) if core['disable_symlinks']['from'] is defined }};
 {% endif %}
-{% if core['error_page'] is defined %}
-{% for page in core['error_page'] %}
+{% if core['error_page'] is defined and core['error_page'] is not string %}
+{% for page in core['error_page'] if core['error_page'] is not mapping %}
 error_page {{ page['code'] if page['code'] is number else page['code'] | join(' ') -}}
 {{- (' ' + page['response'] | string) if page['response'] is defined -}}
 {{- (' ' + page['uri'] | string) if page['uri'] is defined }};
+{% else %}
+error_page {{ core['error_page']['code'] if core['error_page']['code'] is number else core['error_page']['code'] | join(' ') -}}
+{{- (' ' + core['error_page']['response'] | string) if core['error_page']['response'] is defined -}}
+{{- (' ' + core['error_page']['uri'] | string) if core['error_page']['uri'] is defined }};
 {% endfor %}
 {% endif %}
 {% if core['etag'] is defined and core['etag'] is boolean %}
@@ -108,7 +112,7 @@ large_client_header_buffers {{ core['large_client_header_buffers']['number'] }} 
 {% endif %}
 {% if core['limit_except'] is defined %}{# 'limit_except' directive is only available in the location context #}
 limit_except {{ core['limit_except']['method'] if core['limit_except']['method'] is string else core['limit_except']['method'] | join(' ') }} {
-{% if core['limit_except']['directive'] is sequence %}
+{% if core['limit_except']['directive'] is not mapping %}
 {% for directive in core['limit_except']['directive'] if core['limit_except']['directive'] is not string %}
     {{ directive }};
 {% else %}
@@ -260,10 +264,12 @@ tcp_nopush {{ core['tcp_nopush'] | ternary('on', 'off') }};
 {% if core['try_files']['files'] is defined %}{# 'try_files' directive is not available in the 'http' context #}
 try_files {{ core['try_files']['files'] if core['try_files']['files'] is string else core['try_files']['files'] | join(' ') }} {{ core['try_files']['uri'] if core['try_files']['uri'] is defined else core['try_files']['code'] if core['try_files']['code'] is defined }};
 {% endif %}
-{% if core['types'] is defined %}
+{% if core['types'] is defined and core['types'] is not string %}
 types {
-{% for type in core['types'] %}
+{% for type in core['types'] if core['types'] is not mapping %}
     {{ type['mime'] }} {{type['extensions'] if type['extensions'] is string else type['extensions'] | join(' ') }};
+{% else %}
+    {{ core['types']['mime'] }} {{core['types']['extensions'] if core['types']['extensions'] is string else core['types']['extensions'] | join(' ') }};
 {% endfor %}
 }
 {% endif %}

--- a/templates/http/grpc.j2
+++ b/templates/http/grpc.j2
@@ -11,23 +11,15 @@ grpc_buffer_size {{ grpc['buffer_size'] }};
 {% if grpc['connect_timeout'] is defined %}
 grpc_connect_timeout {{ grpc['connect_timeout'] }};
 {% endif %}
-{% if grpc['hide_header'] is defined and grpc['hide_header'] is sequence %}
+{% if grpc['hide_header'] is defined and grpc['hide_header'] is not mapping %}
 {% for header in grpc['hide_header'] if grpc['hide_header'] is not string %}
 grpc_hide_header {{ header }};
 {% else %}
 grpc_hide_header {{ grpc['hide_header'] }};
 {% endfor %}
 {% endif %}
-{% if grpc['ignore_headers'] is defined and grpc['ignore_headers'] is sequence %}
-{% for header in grpc['ignore_headers'] if grpc['ignore_headers'] is not string %}
-{% if header in ['X-Accel-Redirect', 'X-Accel-Charset'] %}
-grpc_ignore_headers {{ header }};
-{% endif %}
-{% else %}
-{% if grpc['ignore_headers'] in ['X-Accel-Redirect', 'X-Accel-Charset'] %}
-grpc_ignore_headers {{ grpc['ignore_headers'] }};
-{% endif %}
-{% endfor %}
+{% if grpc['ignore_headers'] is defined and grpc['ignore_headers'] in ['X-Accel-Redirect', 'X-Accel-Charset'] %}
+grpc_ignore_headers {{ grpc['ignore_headers'] if grpc['ignore_headers'] is string else grpc['ignore_headers'] | join(' ') }};
 {% endif %}
 {% if grpc['intercept_errors'] is defined and grpc['intercept_errors'] is boolean %}
 grpc_intercept_errors {{ grpc['intercept_errors'] | ternary ('on', 'off') }};
@@ -44,7 +36,7 @@ grpc_next_upstream_tries {{ grpc['next_upstream_tries'] }};
 {% if grpc['pass'] is defined %}{# 'pass' directive is only available in the 'location' context #}
 grpc_pass {{ grpc['pass'] }};
 {% endif %}
-{% if grpc['pass_header'] is defined and grpc['pass_header'] is sequence %}
+{% if grpc['pass_header'] is defined and grpc['pass_header'] is not mapping %}
 {% for header in grpc['pass_header'] if grpc['pass_header'] is not string %}
 grpc_pass_header {{ header }};
 {% else %}
@@ -57,8 +49,8 @@ grpc_read_timeout {{ grpc['read_timeout'] }};
 {% if grpc['send_timeout'] is defined %}
 grpc_send_timeout {{ grpc['send_timeout'] }};
 {% endif %}
-{% if grpc['set_header'] is defined and grpc['set_header'] is sequence %}
-{% for header in grpc['set_header'] if grpc['set_header'] is not string %}
+{% if grpc['set_header'] is defined %}
+{% for header in grpc['set_header'] if grpc['set_header'] is not mapping %}
 grpc_set_header {{ header['field'] }} {{ header['value'] }};
 {% else %}
 grpc_set_header {{ grpc['set_header']['field'] }} {{ grpc['set_header']['value'] }};
@@ -76,7 +68,7 @@ grpc_ssl_certificate_key {{ grpc['ssl_certificate_key'] }};
 {% if grpc['ssl_ciphers'] is defined %}
 grpc_ssl_ciphers {{ grpc['ssl_ciphers'] }};
 {% endif %}
-{% if grpc['ssl_conf_command'] is defined and grpc['ssl_conf_command'] is sequence %}
+{% if grpc['ssl_conf_command'] is defined and grpc['ssl_conf_command'] is not mapping %}
 {% for command in grpc['ssl_conf_command'] if grpc['ssl_conf_command'] is not string %}
 grpc_ssl_conf_command {{ command }};
 {% else %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -72,14 +72,14 @@ gzip_vary {{ gzip['vary'] | ternary('on', 'off') }};
 {# NGINX HTTP Headers -- ngx_http_headers_module #}
 {% macro headers(headers) %}
 {% if headers['add_headers'] is defined %}
-{% for header in headers['add_headers'] if (headers['add_headers'] is sequence and headers['add_headers'] is not string) %}
+{% for header in headers['add_headers'] if headers['add_headers'] is not mapping %}
 add_header {{ header['name'] }} {{ header['value'] }}{{ ' always' if header['always'] is defined and header['always'] is boolean and header['always'] | bool }};
 {% else %}
 add_header {{ headers['add_headers']['name'] }} {{ headers['add_headers']['value'] }}{{ ' always' if headers['add_headers']['always'] is defined and headers['add_headers']['always'] is boolean and headers['add_headers']['always'] | bool }};
 {% endfor %}
 {% endif %}
 {% if headers['add_trailers'] is defined %}
-{% for trailer in headers['add_trailers'] if (headers['add_trailers'] is sequence and headers['add_trailers'] is not string) %}
+{% for trailer in headers['add_trailers'] if headers['add_trailers'] is not mapping %}
 add_trailer {{ trailer['name'] }} {{ trailer['value'] }}{{ ' always' if trailer['always'] is defined and trailer['always'] is boolean and trailer['always'] | bool }};
 {% else %}
 add_trailer {{ headers['add_trailers']['name'] }} {{ headers['add_trailers']['value'] }}{{ ' always' if headers['add_trailers']['always'] is defined and headers['add_trailers']['always'] is boolean and headers['add_trailers']['always'] | bool }};
@@ -94,7 +94,7 @@ expires {{ 'off' if not headers['expires'] else (headers['expires'] if headers['
 {# NGINX HTTP Upstream Health Checks -- ngx_http_upstream_hc_module #}
 {# Available only in NGINX Plus #}
 {% macro health_check(health_check) %}
-{% if health_check['health_checks'] is defined %}
+{% if health_check['health_checks'] is defined %}{# 'health_check' directive is only available in the 'location' context #}
 {% for health_check in health_check['health_checks'] %}
 health_check{{ (' interval=' + health_check['interval'] | string) if health_check['interval'] is defined -}}
 {{- (' jitter=' + health_check['jitter'] | string) if health_check['jitter'] is defined -}}
@@ -110,7 +110,7 @@ health_check{{ (' interval=' + health_check['interval'] | string) if health_chec
 {{- (' grpc_status=' + health_check['grpc_status'] | string) if health_check['grpc_status'] is defined }};
 {% endfor %}
 {% endif %}
-{% if health_check['match'] is defined %}
+{% if health_check['match'] is defined and health_check['match'] is not string and health_check['match'] is not mapping %}{# 'match' directive is only available in the 'http' context #}
 {% for match in health_check['match'] %}
 match {{ match['name'] }} {
 {% for condition in match['conditions'] %}
@@ -125,12 +125,12 @@ match {{ match['name'] }} {
 {# NGINX HTTP Keyval -- ngx_http_keyval_module #}
 {# Available only in NGINX Plus #}
 {% macro keyval(keyval) %}
-{% if keyval['keyvals'] is defined %}
+{% if keyval['keyvals'] is defined %}{# 'keyval' directive is only available in the 'http' context #}
 {% for keyval in keyval['keyvals'] %}
 keyval {{ keyval['key'] }} {{ keyval['variable'] }} {{ 'zone=' + keyval['zone']}};
 {% endfor %}
 {% endif %}
-{% if keyval['zones'] is defined %}
+{% if keyval['zones'] is defined %}{# 'keyval_zone' directive is only available in the 'http' context #}
 {% for zone in keyval['zones'] %}
 keyval_zone {{ 'zone=' + zone['name'] + ':' + zone['size'] }}{{ (' state=' + zone['state'] | string) if zone['state'] is defined }}{{ (' timeout=' + zone['timeout'] | string) if zone['timeout'] is defined }}{{ (' type=' + zone['type'] | string) if (zone['type'] is defined and zone['type'] in ['string', 'ip', 'prefix']) }}{{ ' sync' if (zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool) }};
 {% endfor %}
@@ -154,7 +154,7 @@ limit_req_log_level {{ limit_req['log_level'] }};
 {% if limit_req['status'] is defined %}
 limit_req_status {{ limit_req['status'] }};
 {% endif %}
-{% if limit_req['zones'] is defined %}
+{% if limit_req['zones'] is defined %}{# 'limit_req_zone' directive is only available in the 'http' context #}
 {% for zone in limit_req['zones'] %}
 limit_req_zone {{ zone['key'] }} {{ 'zone=' + zone['name'] + ':' + zone['size'] }} {{ 'rate=' + zone['rate'] }}{{ ' sync' if zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool }};
 {% endfor %}
@@ -164,7 +164,7 @@ limit_req_zone {{ zone['key'] }} {{ 'zone=' + zone['name'] + ':' + zone['size'] 
 
 {# NGINX HTTP Log -- ngx_http_log_module #}
 {% macro log(log) %}
-{% if log['format'] is defined %}
+{% if log['format'] is defined %}{# 'log_format' directive is only available in the 'http' context #}
 {% for format in log['format'] %}
 log_format {{ format['name'] }}{{ (' escape=' + format['escape']) if format['escape'] is defined and format['escape'] in ['default', 'json', 'none'] }} {{ format['format'] }};
 {% endfor %}
@@ -181,7 +181,7 @@ access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (
 {% endfor %}
 {% endif %}
 {% if log['error'] is defined %}{# This does not belong here but we are making an exception #}
-{% for log in log['error'] if (log['error'] is sequence and log['error'] is not string) %}
+{% for log in log['error'] if (log['error'] is not mapping and log['error'] is not string) %}
 error_log {{ log if log is string else log['file'] }}{{ (' ' + log['level'] | string) if log['level'] is defined }};
 {% else %}
 error_log {{ log['error'] if log['error'] is string else log['error']['file'] }}{{ (' ' + log['error']['level'] | string) if log['error']['level'] is defined }};
@@ -195,10 +195,10 @@ open_log_file_cache {{ 'off' if not log['open_log_file_cache'] else ('max=' + lo
 
 {# NGINX HTTP Rewrite -- ngx_http_rewrite_module #}
 {% macro rewrite(rewrite) %}
-{% if rewrite['return'] is defined %}
+{% if rewrite['return'] is defined %}{# 'return' directive is not available in the 'http' context #}
 return {{ rewrite['return'] if (rewrite['return'] is string or rewrite['return'] is number) }}{{ rewrite['return']['code'] if rewrite['return']['code'] is defined }}{{ (' ' + rewrite['return']['text'] | string) if rewrite['return']['text'] is defined }}{{ (' ' + rewrite['return']['url']) if rewrite['return']['url'] is defined }};
 {% endif %}
-{% if rewrite['rewrites'] is defined %}
+{% if rewrite['rewrites'] is defined %}{# 'rewrite' directive is not available in the 'http' context #}
 {% for rewrite in rewrite['rewrites'] if (rewrite['rewrites'] is sequence and rewrite['rewrites'] is not string) %}
 rewrite {{ rewrite['regex'] }} {{ rewrite['replacement'] }}{{ (' ' + rewrite['flag']) if (rewrite['flag'] is defined and rewrite['flag'] in ['last', 'break', 'redirect', 'permanent']) }};
 {% endfor %}
@@ -206,8 +206,8 @@ rewrite {{ rewrite['regex'] }} {{ rewrite['replacement'] }}{{ (' ' + rewrite['fl
 {% if rewrite['log'] is defined and rewrite['log'] is boolean %}
 rewrite_log {{ rewrite['log'] | ternary('on', 'off') }};
 {% endif %}
-{% if rewrite['set'] is defined %}
-{% for set in rewrite['set'] if (rewrite['set'] is sequence and rewrite['set'] is not string) %}
+{% if rewrite['set'] is defined %}{# 'set' directive is not available in the 'http' context #}
+{% for set in rewrite['set'] if (rewrite['set'] is not mapping and rewrite['set'] is not string) %}
 set {{ set['variable'] }} {{ set['value'] }};
 {% else %}
 set {{ rewrite['set']['variable'] }} {{ rewrite['set']['value'] }};

--- a/templates/http/proxy.j2
+++ b/templates/http/proxy.j2
@@ -23,7 +23,7 @@ proxy_cache {{ 'off' if not proxy['cache'] else proxy['cache'] }};
 {% if proxy['cache_background_update'] is defined and proxy['cache_background_update'] is boolean %}
 proxy_cache_background_update {{ proxy['cache_background_update'] | ternary('on', 'off') }};
 {% endif %}
-{% if proxy['cache_bypass'] is defined and proxy['cache_bypass'] is sequence %}
+{% if proxy['cache_bypass'] is defined and proxy['cache_bypass'] is not mapping %}
 {% for bypass in proxy['cache_bypass'] if proxy['cache_bypass'] is not string %}
 proxy_cache_bypass {{ bypass if bypass is string else bypass | join(' ') }};
 {% else %}
@@ -88,27 +88,27 @@ proxy_cache_use_stale {{ 'off' if not proxy['cache_use_stale'] else (proxy['cach
 {% for cache in proxy['cache_valid'] if proxy['cache_valid'] is not string %}
 proxy_cache_valid{{ (' ' + cache['code'] | string) if (cache['code'] is defined and (cache['code'] is number or cache['code'] == 'any')) else ((' ' + cache['code'] | join(' ')) if cache['code'] is defined) }} {{ cache if cache is string else cache['time'] if cache['time'] is defined }};
 {% else %}
-proxy_cache_valid{{ (' ' + proxy['cache_valid']['code'] | string) if (proxy['cache_valid']['code'] is defined and (proxy['cache_valid']['code'] is number or proxy['cache_valid']['code'] == 'any')) else ((' ' + proxy['cache_valid']['code'] | join(' ')) if proxy['cache_valid']['code'] is defined) }} {{ proxy['cache_valid'] if proxy['cache_valid'] is string else proxy['cache_valid']['time'] if proxy['cache_valid']['time'] is defined }};
+proxy_cache_valid {{ proxy['cache_valid'] }};
 {% endfor %}
 {% endif %}
 {% if proxy['connect_timeout'] is defined %}
 proxy_connect_timeout {{ proxy['connect_timeout'] }};
 {% endif %}
-{% if proxy['cookie_domain'] is defined and proxy['cookie_domain'] is sequence %}
+{% if proxy['cookie_domain'] is defined and proxy['cookie_domain'] is not mapping and proxy['cookie_domain'] is not boolean %}
 {% for domain in proxy['cookie_domain'] %}
 proxy_cookie_domain {{ domain['domain'] if domain['domain'] is defined }}{{ (' ' + domain['replacement']) if domain['replacement'] is defined }};
 {% endfor %}
 {% elif proxy['cookie_domain'] is defined %}
 proxy_cookie_domain {{ 'off' if not proxy['cookie_domain'] }}{{ proxy['cookie_domain']['domain'] if proxy['cookie_domain']['domain'] is defined }}{{ (' ' + proxy['cookie_domain']['replacement']) if proxy['cookie_domain']['replacement'] is defined }};
 {% endif %}
-{% if proxy['cookie_flags'] is defined and proxy['cookie_flags'] is sequence %}
+{% if proxy['cookie_flags'] is defined and proxy['cookie_flags'] is not mapping and proxy['cookie_flags'] is not boolean %}
 {% for flag in proxy['cookie_flags'] %}
 proxy_cookie_flags {{ flag['cookie'] if flag['cookie'] is defined }}{{ (' ' + (flag['flag'] if flag['flag'] is string else flag['flag'] | join(' '))) if flag['flag'] is defined }};
 {% endfor %}
 {% elif proxy['cookie_flags'] is defined %}
-proxy_cookie_flags {{ 'off' if not proxy['cookie_flags'] }}{{ proxy['cookie_flags']['cookie'] if proxy['cookie_flags']['cookie'] is defined }}{{ (' ' + ( proxy['cookie_flags']['flag'] if  proxy['cookie_flags']['flag'] is string else  proxy['cookie_flags']['flag'] | join(' '))) if  proxy['cookie_flags']['flag'] is defined }};
+proxy_cookie_flags {{ 'off' if not proxy['cookie_flags'] }}{{ proxy['cookie_flags']['cookie'] if proxy['cookie_flags']['cookie'] is defined }}{{ (' ' + (proxy['cookie_flags']['flag'] if proxy['cookie_flags']['flag'] is string else proxy['cookie_flags']['flag'] | join(' '))) if proxy['cookie_flags']['flag'] is defined }};
 {% endif %}
-{% if proxy['cookie_path'] is defined and proxy['cookie_path'] is sequence %}
+{% if proxy['cookie_path'] is defined and proxy['cookie_path'] is not mapping and proxy['cookie_path'] is not boolean %}
 {% for path in proxy['cookie_path'] %}
 proxy_cookie_path {{ path['path'] if path['path'] is defined }}{{ (' ' + path['replacement']) if path['replacement'] is defined }};
 {% endfor %}
@@ -124,7 +124,7 @@ proxy_headers_hash_bucket_size {{ proxy['headers_hash_bucket_size'] }};
 {% if proxy['headers_hash_max_size'] is defined %}
 proxy_headers_hash_max_size {{ proxy['headers_hash_max_size'] }};
 {% endif %}
-{% if proxy['hide_header'] is defined and proxy['hide_header'] is sequence %}
+{% if proxy['hide_header'] is defined and proxy['hide_header'] is not mapping %}
 {% for header in proxy['hide_header'] if proxy['hide_header'] is not string %}
 proxy_hide_header {{ header }};
 {% else %}
@@ -161,7 +161,7 @@ proxy_next_upstream_timeout {{ proxy['next_upstream_timeout'] }};
 {% if proxy['next_upstream_tries'] is defined and proxy['next_upstream_tries'] is number %}
 proxy_next_upstream_tries {{ proxy['next_upstream_tries'] }};
 {% endif %}
-{% if proxy['no_cache'] is defined and proxy['no_cache'] is sequence %}
+{% if proxy['no_cache'] is defined and proxy['no_cache'] is not mapping %}
 {% for no_cache in proxy['no_cache'] if proxy['no_cache'] is not string %}
 proxy_no_cache {{ no_cache if no_cache is string else no_cache | join(' ') }};
 {% else %}
@@ -171,7 +171,7 @@ proxy_no_cache {{ proxy['no_cache'] }};
 {% if proxy['pass'] is defined %}{# 'pass' directive is only available in the 'location' context #}
 proxy_pass {{ proxy['pass'] }};
 {% endif %}
-{% if proxy['pass_header'] is defined and proxy['pass_header'] is sequence %}
+{% if proxy['pass_header'] is defined and proxy['pass_header'] is not mapping %}
 {% for header in proxy['pass_header'] if proxy['pass_header'] is not string %}
 proxy_pass_header {{ header }};
 {% else %}
@@ -187,7 +187,7 @@ proxy_pass_request_headers {{ proxy['pass_request_headers'] | ternary('on', 'off
 {% if proxy['read_timeout'] is defined %}
 proxy_read_timeout {{ proxy['read_timeout'] }};
 {% endif %}
-{% if proxy['redirect'] is defined and proxy['redirect'] is sequence %}
+{% if proxy['redirect'] is defined and proxy['redirect'] is not mapping and proxy['redirect'] is not boolean %}
 {% for redirect in proxy['redirect'] %}
 proxy_redirect {{ redirect if redirect == 'default' }}{{ ((redirect['original'] | string) + ' ' + (redirect['replacement'] | string)) if (redirect['original'] is defined and redirect['replacement'] is defined) }};
 {% endfor %}
@@ -207,7 +207,7 @@ proxy_send_timeout {{ proxy['send_timeout'] }};
 proxy_set_body {{ proxy['set_body'] }};
 {% endif %}
 {% if proxy['set_header'] is defined %}
-{% for header in proxy['set_header'] if (proxy['set_header'] is sequence and proxy['set_header'] is not string) %}
+{% for header in proxy['set_header'] if proxy['set_header'] is not mapping %}
 proxy_set_header {{ header['field'] }} {{ header['value'] }};
 {% else %}
 proxy_set_header {{ proxy['set_header']['field'] }} {{ proxy['set_header']['value'] }};
@@ -225,7 +225,7 @@ proxy_ssl_certificate_key {{ proxy['ssl_certificate_key'] }};
 {% if proxy['ssl_ciphers'] is defined %}
 proxy_ssl_ciphers {{ proxy['ssl_ciphers'] if proxy['ssl_ciphers'] is string else proxy['ssl_ciphers'] | join(':') }};
 {% endif %}
-{% if proxy['ssl_conf_command'] is defined and proxy['ssl_conf_command'] is sequence %}
+{% if proxy['ssl_conf_command'] is defined and proxy['ssl_conf_command'] is not mapping %}
 {% for command in proxy['ssl_conf_command'] if proxy['ssl_conf_command'] is not string %}
 proxy_ssl_conf_command {{ command }};
 {% else %}

--- a/templates/http/ssl.j2
+++ b/templates/http/ssl.j2
@@ -5,14 +5,14 @@
 {% if ssl['buffer_size'] is defined %}
 ssl_buffer_size {{ ssl['buffer_size'] }};
 {% endif %}
-{% if ssl['certificate'] is defined and ssl['certificate'] is sequence %}
+{% if ssl['certificate'] is defined and ssl['certificate'] is not mapping %}
 {% for certificate in ssl['certificate'] if ssl['certificate'] is not string %}
 ssl_certificate {{ certificate }};
 {% else %}
 ssl_certificate {{ ssl['certificate'] }};
 {% endfor %}
 {% endif %}
-{% if ssl['certificate_key'] is defined and ssl['certificate_key'] is sequence %}
+{% if ssl['certificate_key'] is defined and ssl['certificate_key'] is not mapping %}
 {% for key in ssl['certificate_key'] if ssl['certificate_key'] is not string %}
 ssl_certificate_key {{ key }};
 {% else %}
@@ -25,7 +25,7 @@ ssl_ciphers {{ ssl['ciphers'] if ssl['ciphers'] is string else ssl['ciphers'] | 
 {% if ssl['client_certificate'] is defined %}
 ssl_client_certificate {{ ssl['client_certificate'] }};
 {% endif %}
-{% if ssl['conf_command'] is defined and ssl['conf_command'] is sequence %}
+{% if ssl['conf_command'] is defined and ssl['conf_command'] is not mapping %}
 {% for command in ssl['conf_command'] if ssl['conf_command'] is not string %}
 ssl_conf_command {{ command }};
 {% else %}
@@ -71,7 +71,7 @@ ssl_session_cache {{ 'off' if not ssl['session_cache'] -}}
 {{- ('builtin' if (ssl['session_cache']['builtin']['enable'] is defined and ssl['session_cache']['builtin']['enable'] is boolean and ssl['session_cache']['builtin']['enable'] | bool)) + (':' + ssl['session_cache']['builtin']['size'] | string) if ssl['session_cache']['builtin']['size'] is defined -}}
 {{- ('shared:' + ssl['session_cache']['shared']['name'] | string + ':' + ssl['session_cache']['shared']['size'] | string) if (ssl['session_cache']['shared']['name'] is defined and ssl['session_cache']['shared']['size'] is defined) }};
 {% endif %}
-{% if ssl['session_ticket_key'] is defined and ssl['session_ticket_key'] is sequence %}
+{% if ssl['session_ticket_key'] is defined and ssl['session_ticket_key'] is not mapping %}
 {% for key in ssl['session_ticket_key'] if ssl['session_ticket_key'] is not string %}
 ssl_session_ticket_key {{ key }};
 {% else %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -16,7 +16,7 @@ events {
 
 {% if nginx_config_main_template['config']['http'] is defined %}
 http {
-{% if nginx_config_main_template['config']['http']['include'] is defined and nginx_config_main_template['config']['http']['include'] is sequence %}
+{% if nginx_config_main_template['config']['http']['include'] is defined and nginx_config_main_template['config']['http']['include'] is not mapping %}
 {% for file in nginx_config_main_template['config']['http']['include'] if nginx_config_main_template['config']['http']['include'] is not string %}
     include {{ file }};
 {% else %}
@@ -28,7 +28,7 @@ http {
 
 {% if nginx_config_main_template['config']['stream'] is defined %}
 stream {
-{% if nginx_config_main_template['config']['stream']['include'] is defined and nginx_config_main_template['config']['stream']['include'] is sequence %}
+{% if nginx_config_main_template['config']['stream']['include'] is defined and nginx_config_main_template['config']['stream']['include'] is not mapping %}
 {% for file in nginx_config_main_template['config']['stream']['include'] if nginx_config_main_template['config']['stream']['include'] is not string %}
     include {{ file }};
 {% else %}


### PR DESCRIPTION
### Proposed changes

Dictionaries are a sequence per Jinja2 contrary to Python's defaults (dictionaries are not a sequence in Python). The template conditionals assumed the latter. This PR replaces all sequence checks with mapping (dictionary) checks.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
