### PR TITLE
Transform objects to strings before conducting Jinja2 operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ BUG FIXES:
 
 * Dictionaries are a sequence per Jinja2 contrary to Python's defaults (dictionaries are not a sequence in Python). The template conditionals assumed the latter.
 * NAP DoS monitor directive would fail if some variables were commented out.
+* NGINX listen `so_keepalive` parameter was not working as intended when setting specific values.
+* Make sure all template objects are properly transformed into strings before doing Jinja2 operations.
+* Remove unnecessary parentheses.
 
 ## 0.4.1 (October 25, 2021)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -513,10 +513,15 @@
                         port: 443
                         default_server: true
                         ssl: false
+                        so_keepalive:
+                          keepidle: 30m
+                          keepintvl: 5
+                          keepcnt: 10
                       - address: "[::]"
                         port: 80
                         default_server: true
                         ssl: false
+                    open_file_cache: false
                     server_name: localhost
                     try_files:
                       files: $uri

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -45,7 +45,7 @@ auth_request_set {{ auth_request['set']['variable'] }} {{ auth_request['set']['v
 {# NGINX HTTP Auth JWT -- ngx_http_auth_jwt_module #}
 {% macro auth_jwt(auth_jwt) %}
 {% if auth_jwt['enable'] is defined %}
-auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined }}{{ (' token=' + auth_jwt['enable']['token'] if auth_jwt['enable']['token'] is defined) }};
+auth_jwt {{ 'off' if not auth_jwt['enable'] }}{{ auth_jwt['enable']['realm'] if auth_jwt['enable']['realm'] is defined }}{{ (' token=' + auth_jwt['enable']['token'] | string) if auth_jwt['enable']['token'] is defined }};
 {% endif %}
 {% if auth_jwt['claim_set'] is defined %}{# 'claim_set' is only available in the 'http' context #}
 {% for claim in auth_jwt['claim_set'] if (auth_jwt['claim_set'] is not mapping and auth_jwt['claim_set'] is not string) %}

--- a/templates/http/core.j2
+++ b/templates/http/core.j2
@@ -7,7 +7,7 @@ absolute_redirect {{ core['absolute_redirect'] | ternary('on', 'off') }};
 {% endif %}
 {% if core['aio'] is defined %}
 aio {{ (core['aio'] | ternary('on', 'off')) if core['aio'] is boolean -}}
-    {{- ('threads' if core['aio']['threads'] is defined and not core['aio']['threads'] is sameas false) -}}
+    {{- 'threads' if core['aio']['threads'] is defined and not core['aio']['threads'] is sameas false -}}
     {{- ('=' + core['aio']['threads'] | string) if core['aio']['threads'] is not boolean }};
 {% endif %}
 {% if core['aio_write'] is defined and core['aio_write'] is boolean %}
@@ -62,8 +62,8 @@ directio {{ 'off' if not core['directio'] else core['directio'] }};
 directio_alignment {{ core['directio_alignment'] }};
 {% endif %}
 {% if core['disable_symlinks'] is defined %}
-disable_symlinks {{ (core['disable_symlinks'] | ternary('on', 'off')) if core['disable_symlinks'] is boolean else 'if_not_owner' if core['disable_symlinks'] == 'if_not_owner' -}}
-                 {{- core['disable_symlinks']['check'] if core['disable_symlinks']['check'] is defined and core['disable_symlinks']['check'] in ['on', 'if_not_owner'] }}{{ (' from=' + core['disable_symlinks']['from']) if core['disable_symlinks']['from'] is defined }};
+disable_symlinks {{ core['disable_symlinks'] | ternary('on', 'off') if core['disable_symlinks'] is boolean else 'if_not_owner' if core['disable_symlinks'] == 'if_not_owner' -}}
+                 {{- core['disable_symlinks']['check'] if core['disable_symlinks']['check'] is defined and core['disable_symlinks']['check'] in ['on', 'if_not_owner'] }}{{ (' from=' + core['disable_symlinks']['from'] | string) if core['disable_symlinks']['from'] is defined }};
 {% endif %}
 {% if core['error_page'] is defined and core['error_page'] is not string %}
 {% for page in core['error_page'] if core['error_page'] is not mapping %}
@@ -138,22 +138,23 @@ lingering_timeout {{ core['lingering_timeout'] }};
 {% endif %}
 {% if core['listen'] is defined %}{# 'listen' directive is only available in the 'server' context #}
 {% for listen in core['listen'] %}
-listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if (listen['address'] is defined and listen['port'] is defined) }}{{ listen['port'] if listen['port'] is defined -}}
+listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if listen['address'] is defined and listen['port'] is defined }}{{ listen['port'] if listen['port'] is defined -}}
 {{- ' default_server' if listen['default_server'] is defined and listen['default_server'] is boolean and listen['default_server'] | bool -}}
 {{- ' ssl' if listen['ssl'] is defined and listen['ssl'] is boolean and listen['ssl'] | bool -}}
-{{- ' http2' if (listen['http2'] is defined and listen['http2'] is boolean and listen['http2'] | bool) else ' spdy' if (listen['spdy'] is defined and listen['spdy'] is boolean and listen['spdy'] | bool) -}}
-{{- ' proxy_protocol' if (listen['proxy_protocol'] is defined and listen['proxy_protocol'] is boolean and listen['proxy_protocol'] | bool) -}}
+{{- ' http2' if listen['http2'] is defined and listen['http2'] is boolean and listen['http2'] | bool else ' spdy' if listen['spdy'] is defined and listen['spdy'] is boolean and listen['spdy'] | bool -}}
+{{- ' proxy_protocol' if listen['proxy_protocol'] is defined and listen['proxy_protocol'] is boolean and listen['proxy_protocol'] | bool -}}
 {{- (' setfib=' + listen['setfib'] | string) if listen['setfib'] is defined -}}
 {{- (' fastopen=' + listen['fastopen'] | string) if listen['fastopen'] is defined and listen['fastopen'] is number -}}
 {{- (' backlog=' + listen['backlog'] | string) if listen['backlog'] is defined and listen['backlog'] is number -}}
 {{- (' rcvbuf=' + listen['rcvbuf'] | string) if listen['rcvbuf'] is defined -}}
 {{- (' sndbuf=' + listen['sndbuf'] | string) if listen['sndbuf'] is defined -}}
 {{- (' accept_filter=' + listen['accept_filter'] | string) if listen['accept_filter'] is defined -}}
-{{- ' deferred' if (listen['deferred'] is defined and listen['deferred'] is boolean and listen['deferred'] | bool) -}}
-{{- ' bind' if (listen['bind'] is defined and listen['bind'] is boolean and listen['bind'] | bool) -}}
-{{- (' ipv6only=' + listen['ipv6only'] | ternary('on', 'off')) if listen['ipv6only'] is defined -}}
+{{- ' deferred' if listen['deferred'] is defined and listen['deferred'] is boolean and listen['deferred'] | bool -}}
+{{- ' bind' if listen['bind'] is defined and listen['bind'] is boolean and listen['bind'] | bool -}}
+{{- (' ipv6only=' + listen['ipv6only'] | ternary('on', 'off')) if listen['ipv6only'] is defined and listen['ipv6only'] is boolean -}}
 {{- ' reuseport' if (listen['reuseport'] is defined and listen['reuseport'] is boolean and listen['reuseport'] | bool) -}}
-{{- (' so_keepalive=' + (listen['so_keepalive'] | ternary('on', 'off')) if listen['so_keepalive'] is defined and listen['so_keepalive'] is boolean else ((listen['so_keepalive']['keepidle'] if listen['so_keepalive']['keepidle'] is defined else '') + ':' + (listen['so_keepalive']['keepintvl'] if listen['so_keepalive']['keepintvl'] is defined else '') + ':' + listen['so_keepalive']['keepcnt'] if listen['so_keepalive']['keepcnt'] is defined else '')) }};
+{{- (' so_keepalive=' + listen['so_keepalive'] | ternary('on', 'off')) if listen['so_keepalive'] is defined and listen['so_keepalive'] is boolean -}}
+{{- (' so_keepalive=' + (listen['so_keepalive']['keepidle'] | string if listen['so_keepalive']['keepidle'] is defined) + ':' + (listen['so_keepalive']['keepintvl'] | string if listen['so_keepalive']['keepintvl'] is defined) + ':' + (listen['so_keepalive']['keepcnt'] | string if listen['so_keepalive']['keepcnt'] is defined)) if listen['so_keepalive'] is defined and listen['so_keepalive'] is mapping }};
 {% endfor %}
 {% endif %}
 {% if core['log_not_found'] is defined and core['log_not_found'] is boolean %}
@@ -210,7 +211,7 @@ reset_timedout_connection {{ core['reset_timedout_connection'] | ternary('on', '
 {% if core['resolver']['address'] is defined %}
 resolver {{ core['resolver']['address'] if core['resolver']['address'] is string else core['resolver']['address'] | join(' ') -}}
 {{- (' valid=' + core['resolver']['valid'] | string) if core['resolver']['valid'] is defined -}}
-{{- (' ipv6=' + (core['resolver']['ipv6'] | ternary('on', 'off'))) if core['resolver']['ipv6'] is defined and core['resolver']['ipv6'] is boolean -}}
+{{- (' ipv6=' + core['resolver']['ipv6'] | ternary('on', 'off')) if core['resolver']['ipv6'] is defined and core['resolver']['ipv6'] is boolean -}}
 {{- (' status_zone=' + core['resolver']['status_zone'] | string) if core['resolver']['status_zone'] is defined }};
 {% endif %}
 {% if core['resolver_timeout'] is defined %}

--- a/templates/http/grpc.j2
+++ b/templates/http/grpc.j2
@@ -3,7 +3,7 @@
 {# NGINX HTTP GRPC template -- ngx_http_grpc_module #}
 {% macro grpc(grpc) %}
 {% if grpc['bind'] is defined %}
-grpc_bind {{ 'off' if not grpc['bind'] }}{{ (grpc['bind']['address']) if grpc['bind']['address'] is defined }}{{' transparent' if (grpc['bind']['transparent'] is defined and grpc['bind']['transparent'] is boolean and grpc['bind']['transparent'] | bool) }};
+grpc_bind {{ 'off' if not grpc['bind'] }}{{ grpc['bind']['address'] if grpc['bind']['address'] is defined }}{{' transparent' if grpc['bind']['transparent'] is defined and grpc['bind']['transparent'] is boolean and grpc['bind']['transparent'] | bool }};
 {% endif %}
 {% if grpc['buffer_size'] is defined %}
 grpc_buffer_size {{ grpc['buffer_size'] }};

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -98,14 +98,14 @@ expires {{ 'off' if not headers['expires'] else (headers['expires'] if headers['
 {% for health_check in health_check['health_checks'] %}
 health_check{{ (' interval=' + health_check['interval'] | string) if health_check['interval'] is defined -}}
 {{- (' jitter=' + health_check['jitter'] | string) if health_check['jitter'] is defined -}}
-{{- (' fails=' + health_check['fails'] | string) if (health_check['fails'] is defined and health_check['fails'] is number) -}}
-{{- (' passes=' + health_check['passes'] | string) if (health_check['passes'] is defined and health_check['passes'] is number) -}}
+{{- (' fails=' + health_check['fails'] | string) if health_check['fails'] is defined and health_check['fails'] is number -}}
+{{- (' passes=' + health_check['passes'] | string) if health_check['passes'] is defined and health_check['passes'] is number -}}
 {{- (' uri=' + health_check['uri'] | string) if health_check['uri'] is defined -}}
-{{- ' mandatory' if (health_check['mandatory'] is defined and health_check['mandatory'] is boolean and health_check['mandatory'] | bool) -}}
-{{- ' persistent' if (health_check['persistent'] is defined and health_check['persistent'] is boolean and health_check['persistent'] | bool) -}}
+{{- ' mandatory' if health_check['mandatory'] is defined and health_check['mandatory'] is boolean and health_check['mandatory'] | bool -}}
+{{- ' persistent' if health_check['persistent'] is defined and health_check['persistent'] is boolean and health_check['persistent'] | bool -}}
 {{- (' match=' + health_check['match'] | string) if health_check['match'] is defined -}}
 {{- (' port=' + health_check['port'] | string) if health_check['port'] is defined -}}
-{{- ' type=grpc' if (health_check['grpc_service'] is defined or health_check['grpc_status'] is defined) -}}
+{{- ' type=grpc' if health_check['grpc_service'] is defined or health_check['grpc_status'] is defined -}}
 {{- (' grpc_service=' + health_check['grpc_service'] | string) if health_check['grpc_service'] is defined -}}
 {{- (' grpc_status=' + health_check['grpc_status'] | string) if health_check['grpc_status'] is defined }};
 {% endfor %}
@@ -127,12 +127,12 @@ match {{ match['name'] }} {
 {% macro keyval(keyval) %}
 {% if keyval['keyvals'] is defined %}{# 'keyval' directive is only available in the 'http' context #}
 {% for keyval in keyval['keyvals'] %}
-keyval {{ keyval['key'] }} {{ keyval['variable'] }} {{ 'zone=' + keyval['zone']}};
+keyval {{ keyval['key'] }} {{ keyval['variable'] }} {{ 'zone=' + keyval['zone'] | string }};
 {% endfor %}
 {% endif %}
 {% if keyval['zones'] is defined %}{# 'keyval_zone' directive is only available in the 'http' context #}
 {% for zone in keyval['zones'] %}
-keyval_zone {{ 'zone=' + zone['name'] + ':' + zone['size'] }}{{ (' state=' + zone['state'] | string) if zone['state'] is defined }}{{ (' timeout=' + zone['timeout'] | string) if zone['timeout'] is defined }}{{ (' type=' + zone['type'] | string) if (zone['type'] is defined and zone['type'] in ['string', 'ip', 'prefix']) }}{{ ' sync' if (zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool) }};
+keyval_zone {{ 'zone=' + zone['name'] | string + ':' + zone['size'] | string }}{{ (' state=' + zone['state'] | string) if zone['state'] is defined }}{{ (' timeout=' + zone['timeout'] | string) if zone['timeout'] is defined }}{{ (' type=' + zone['type'] | string) if zone['type'] is defined and zone['type'] in ['string', 'ip', 'prefix'] }}{{ ' sync' if zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool }};
 {% endfor %}
 {% endif %}
 
@@ -142,7 +142,7 @@ keyval_zone {{ 'zone=' + zone['name'] + ':' + zone['size'] }}{{ (' state=' + zon
 {% macro limit_req(limit_req) %}
 {% if limit_req['limit_reqs'] is defined %}
 {% for limit in limit_req['limit_reqs'] %}
-limit_req {{ 'zone=' + limit['zone'] }}{{ ' burst=' + limit['burst'] | string }}{{ (' nodelay' if not limit['delay'] else (' delay=' + limit['delay'] | string)) if limit['delay'] is defined }};
+limit_req {{ 'zone=' + limit['zone'] | string }}{{ ' burst=' + limit['burst'] | string }}{{ (' nodelay' if not limit['delay'] else (' delay=' + limit['delay'] | string)) if limit['delay'] is defined }};
 {% endfor %}
 {% endif %}
 {% if limit_req['dry_run'] is defined and limit_req['dry_run'] is boolean %}
@@ -156,7 +156,7 @@ limit_req_status {{ limit_req['status'] }};
 {% endif %}
 {% if limit_req['zones'] is defined %}{# 'limit_req_zone' directive is only available in the 'http' context #}
 {% for zone in limit_req['zones'] %}
-limit_req_zone {{ zone['key'] }} {{ 'zone=' + zone['name'] + ':' + zone['size'] }} {{ 'rate=' + zone['rate'] }}{{ ' sync' if zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool }};
+limit_req_zone {{ zone['key'] }} {{ 'zone=' + zone['name'] | string + ':' + zone['size'] | string }} {{ 'rate=' + zone['rate'] | string }}{{ ' sync' if zone['sync'] is defined and zone['sync'] is boolean and zone['sync'] | bool }};
 {% endfor %}
 {% endif %}
 
@@ -166,14 +166,14 @@ limit_req_zone {{ zone['key'] }} {{ 'zone=' + zone['name'] + ':' + zone['size'] 
 {% macro log(log) %}
 {% if log['format'] is defined %}{# 'log_format' directive is only available in the 'http' context #}
 {% for format in log['format'] %}
-log_format {{ format['name'] }}{{ (' escape=' + format['escape']) if format['escape'] is defined and format['escape'] in ['default', 'json', 'none'] }} {{ format['format'] }};
+log_format {{ format['name'] }}{{ (' escape=' + format['escape'] | string) if format['escape'] is defined and format['escape'] in ['default', 'json', 'none'] }} {{ format['format'] }};
 {% endfor %}
 {% endif %}
 {% if log['access'] is defined and log['access'] is boolean and not log['access'] | bool %}
 access_log {{ 'off' }};
 {% elif log['access'] is defined %}
 {% for log in log['access'] %}
-access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (' ' + log['format']) if log['format'] is defined -}}
+access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (' ' + log['format'] | string) if log['format'] is defined -}}
 {{- (' buffer=' + log['buffer'] | string) if log['buffer'] is defined -}}
 {{- ' gzip' if log['gzip'] is defined and log['access']['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and log['gzip'] is string -}}
 {{- (' flush=' + log['flush'] | string) if log['flush'] is defined -}}
@@ -196,11 +196,11 @@ open_log_file_cache {{ 'off' if not log['open_log_file_cache'] else ('max=' + lo
 {# NGINX HTTP Rewrite -- ngx_http_rewrite_module #}
 {% macro rewrite(rewrite) %}
 {% if rewrite['return'] is defined %}{# 'return' directive is not available in the 'http' context #}
-return {{ rewrite['return'] if (rewrite['return'] is string or rewrite['return'] is number) }}{{ rewrite['return']['code'] if rewrite['return']['code'] is defined }}{{ (' ' + rewrite['return']['text'] | string) if rewrite['return']['text'] is defined }}{{ (' ' + rewrite['return']['url']) if rewrite['return']['url'] is defined }};
+return {{ rewrite['return'] if (rewrite['return'] is string or rewrite['return'] is number) }}{{ rewrite['return']['code'] if rewrite['return']['code'] is defined }}{{ (' ' + rewrite['return']['text'] | string) if rewrite['return']['text'] is defined }}{{ (' ' + rewrite['return']['url'] | string) if rewrite['return']['url'] is defined }};
 {% endif %}
 {% if rewrite['rewrites'] is defined %}{# 'rewrite' directive is not available in the 'http' context #}
 {% for rewrite in rewrite['rewrites'] if (rewrite['rewrites'] is sequence and rewrite['rewrites'] is not string) %}
-rewrite {{ rewrite['regex'] }} {{ rewrite['replacement'] }}{{ (' ' + rewrite['flag']) if (rewrite['flag'] is defined and rewrite['flag'] in ['last', 'break', 'redirect', 'permanent']) }};
+rewrite {{ rewrite['regex'] }} {{ rewrite['replacement'] }}{{ (' ' + rewrite['flag'] | string) if rewrite['flag'] is defined and rewrite['flag'] in ['last', 'break', 'redirect', 'permanent'] }};
 {% endfor %}
 {% endif %}
 {% if rewrite['log'] is defined and rewrite['log'] is boolean %}

--- a/templates/http/proxy.j2
+++ b/templates/http/proxy.j2
@@ -58,19 +58,19 @@ proxy_cache_min_uses {{ proxy['cache_min_uses'] }};
 {% for proxy in proxy['cache_path'] %}
 proxy_cache_path {{ proxy['path'] -}}
 {{- (' levels=' + proxy['levels'] | string) if proxy['levels'] is defined -}}
-{{- (' use_temp_path=' + (proxy['use_temp_path'] | ternary('on', 'off'))) if (proxy['use_temp_path'] is defined and proxy['use_temp_path'] is boolean) -}}
-{{- (' keys_zone=' + proxy['keys_zone']['name'] | string + ':' + (proxy['keys_zone']['size'] | string)) if (proxy['keys_zone']['name'] is defined and proxy['keys_zone']['size'] is defined) -}}
+{{- (' use_temp_path=' + proxy['use_temp_path'] | ternary('on', 'off')) if proxy['use_temp_path'] is defined and proxy['use_temp_path'] is boolean -}}
+{{- (' keys_zone=' + proxy['keys_zone']['name'] | string + ':' + proxy['keys_zone']['size'] | string) if proxy['keys_zone']['name'] is defined and proxy['keys_zone']['size'] is defined -}}
 {{- (' inactive=' + proxy['inactive'] | string) if proxy['inactive'] is defined -}}
 {{- (' max_size=' + proxy['max_size'] | string) if proxy['max_size'] is defined -}}
 {{- (' min_free=' + proxy['min_free'] | string) if proxy['min_free'] is defined -}}
-{{- (' manager_files=' + proxy['manager_files'] | string) if (proxy['manager_files'] is defined and proxy['manager_files'] is number) -}}
+{{- (' manager_files=' + proxy['manager_files'] | string) if proxy['manager_files'] is defined and proxy['manager_files'] is number -}}
 {{- (' manager_sleep=' + proxy['manager_sleep'] | string) if proxy['manager_sleep'] is defined -}}
 {{- (' manager_threshold=' + proxy['manager_threshold'] | string) if proxy['manager_threshold'] is defined -}}
-{{- (' loader_files=' + proxy['loader_files'] | string) if (proxy['loader_files'] is defined and proxy['loader_files'] is number) -}}
+{{- (' loader_files=' + proxy['loader_files'] | string) if proxy['loader_files'] is defined and proxy['loader_files'] is number -}}
 {{- (' loader_sleep=' + proxy['loader_sleep'] | string) if proxy['loader_sleep'] is defined -}}
 {{- (' loader_threshold=' + proxy['loader_threshold'] | string) if proxy['loader_threshold'] is defined -}}
-{{- (' purger=' + (proxy['purger'] | ternary('on', 'off'))) if (proxy['purger'] is defined and proxy['cache_path']['purger'] is boolean) -}}
-{{- (' purger_files=' + proxy['purger_files'] | string) if (proxy['purger_files'] is defined and proxy['purger_files'] is number) -}}
+{{- (' purger=' + proxy['purger'] | ternary('on', 'off')) if proxy['purger'] is defined and proxy['cache_path']['purger'] is boolean -}}
+{{- (' purger_files=' + proxy['purger_files'] | string) if proxy['purger_files'] is defined and proxy['purger_files'] is number -}}
 {{- (' purger_sleep=' + proxy['purger_sleep'] | string) if proxy['purger_sleep'] is defined -}}
 {{- (' purger_threshold=' + proxy['purger_threshold'] | string) if proxy['purger_threshold'] is defined }};
 {% endfor %}
@@ -86,7 +86,7 @@ proxy_cache_use_stale {{ 'off' if not proxy['cache_use_stale'] else (proxy['cach
 {% endif %}
 {% if proxy['cache_valid'] is defined %}
 {% for cache in proxy['cache_valid'] if proxy['cache_valid'] is not string %}
-proxy_cache_valid{{ (' ' + cache['code'] | string) if (cache['code'] is defined and (cache['code'] is number or cache['code'] == 'any')) else ((' ' + cache['code'] | join(' ')) if cache['code'] is defined) }} {{ cache if cache is string else cache['time'] if cache['time'] is defined }};
+proxy_cache_valid{{ (' ' + cache['code'] | string) if cache['code'] is defined and (cache['code'] is number or cache['code'] == 'any') else (' ' + cache['code'] | join(' ') if cache['code'] is defined) }} {{ cache if cache is string else cache['time'] if cache['time'] is defined }};
 {% else %}
 proxy_cache_valid {{ proxy['cache_valid'] }};
 {% endfor %}
@@ -96,10 +96,10 @@ proxy_connect_timeout {{ proxy['connect_timeout'] }};
 {% endif %}
 {% if proxy['cookie_domain'] is defined and proxy['cookie_domain'] is not mapping and proxy['cookie_domain'] is not boolean %}
 {% for domain in proxy['cookie_domain'] %}
-proxy_cookie_domain {{ domain['domain'] if domain['domain'] is defined }}{{ (' ' + domain['replacement']) if domain['replacement'] is defined }};
+proxy_cookie_domain {{ domain['domain'] if domain['domain'] is defined }}{{ (' ' + domain['replacement'] | string) if domain['replacement'] is defined }};
 {% endfor %}
 {% elif proxy['cookie_domain'] is defined %}
-proxy_cookie_domain {{ 'off' if not proxy['cookie_domain'] }}{{ proxy['cookie_domain']['domain'] if proxy['cookie_domain']['domain'] is defined }}{{ (' ' + proxy['cookie_domain']['replacement']) if proxy['cookie_domain']['replacement'] is defined }};
+proxy_cookie_domain {{ 'off' if not proxy['cookie_domain'] }}{{ proxy['cookie_domain']['domain'] if proxy['cookie_domain']['domain'] is defined }}{{ (' ' + proxy['cookie_domain']['replacement'] | string) if proxy['cookie_domain']['replacement'] is defined }};
 {% endif %}
 {% if proxy['cookie_flags'] is defined and proxy['cookie_flags'] is not mapping and proxy['cookie_flags'] is not boolean %}
 {% for flag in proxy['cookie_flags'] %}
@@ -110,10 +110,10 @@ proxy_cookie_flags {{ 'off' if not proxy['cookie_flags'] }}{{ proxy['cookie_flag
 {% endif %}
 {% if proxy['cookie_path'] is defined and proxy['cookie_path'] is not mapping and proxy['cookie_path'] is not boolean %}
 {% for path in proxy['cookie_path'] %}
-proxy_cookie_path {{ path['path'] if path['path'] is defined }}{{ (' ' + path['replacement']) if path['replacement'] is defined }};
+proxy_cookie_path {{ path['path'] if path['path'] is defined }}{{ (' ' + path['replacement'] | string) if path['replacement'] is defined }};
 {% endfor %}
 {% elif proxy['cookie_path'] is defined %}
-proxy_cookie_path {{ 'off' if not proxy['cookie_path'] }}{{ proxy['cookie_path']['path'] if proxy['cookie_path']['path'] is defined }}{{ (' ' + proxy['cookie_path']['replacement']) if proxy['cookie_path']['replacement'] is defined }};
+proxy_cookie_path {{ 'off' if not proxy['cookie_path'] }}{{ proxy['cookie_path']['path'] if proxy['cookie_path']['path'] is defined }}{{ (' ' + proxy['cookie_path']['replacement'] | string) if proxy['cookie_path']['replacement'] is defined }};
 {% endif %}
 {% if proxy['force_ranges'] is defined and proxy['force_ranges'] is boolean %}
 proxy_force_ranges {{ proxy['force_ranges'] | ternary('on', 'off') }};
@@ -189,10 +189,10 @@ proxy_read_timeout {{ proxy['read_timeout'] }};
 {% endif %}
 {% if proxy['redirect'] is defined and proxy['redirect'] is not mapping and proxy['redirect'] is not boolean %}
 {% for redirect in proxy['redirect'] %}
-proxy_redirect {{ redirect if redirect == 'default' }}{{ ((redirect['original'] | string) + ' ' + (redirect['replacement'] | string)) if (redirect['original'] is defined and redirect['replacement'] is defined) }};
+proxy_redirect {{ redirect if redirect == 'default' }}{{ (redirect['original'] | string + ' ' + redirect['replacement'] | string) if redirect['original'] is defined and redirect['replacement'] is defined }};
 {% endfor %}
 {% elif proxy['redirect'] is defined %}
-proxy_redirect {{ 'off' if not proxy['redirect'] else proxy['redirect'] if proxy['redirect'] == 'default' }}{{ ((proxy['redirect']['original'] | string) + ' ' + (proxy['redirect']['replacement'] | string)) if (proxy['redirect']['original'] is defined and proxy['redirect']['replacement'] is defined) }};
+proxy_redirect {{ 'off' if not proxy['redirect'] else proxy['redirect'] if proxy['redirect'] == 'default' }}{{ (proxy['redirect']['original'] | string + ' ' + proxy['redirect']['replacement'] | string) if proxy['redirect']['original'] is defined and proxy['redirect']['replacement'] is defined }};
 {% endif %}
 {% if proxy['request_buffering'] is defined and proxy['request_buffering'] is boolean %}
 proxy_request_buffering {{ proxy['request_buffering'] | ternary('on', 'off') }};
@@ -263,9 +263,9 @@ proxy_ssl_verify_depth {{ proxy['ssl_verify_depth'] }};
 proxy_store {{ (proxy['store'] | ternary('on', 'off')) if proxy['store'] is boolean else proxy['store'] }};
 {% endif %}
 {% if proxy['store_access'] is defined %}
-proxy_store_access{{ ' user:' + proxy['store_access']['user'] if proxy['store_access']['user'] is defined -}}
-{{- ' group:' + proxy['store_access']['group'] if proxy['store_access']['group'] is defined -}}
-{{- ' all:' + proxy['store_access']['all'] if proxy['store_access']['all'] is defined }};
+proxy_store_access{{ (' user:' + proxy['store_access']['user'] | string) if proxy['store_access']['user'] is defined -}}
+{{- (' group:' + proxy['store_access']['group'] | string) if proxy['store_access']['group'] is defined -}}
+{{- (' all:' + proxy['store_access']['all'] | string) if proxy['store_access']['all'] is defined }};
 {% endif %}
 {% if proxy['temp_file_write_size'] is defined %}
 proxy_temp_file_write_size {{ proxy['temp_file_write_size'] }};

--- a/templates/http/ssl.j2
+++ b/templates/http/ssl.j2
@@ -68,8 +68,8 @@ ssl_reject_handshake {{ ssl['reject_handshake'] | ternary('on', 'off') }};
 {% if ssl['session_cache'] is defined %}
 ssl_session_cache {{ 'off' if not ssl['session_cache'] -}}
 {{- 'none' if (ssl['session_cache'] == 'none') -}}
-{{- ('builtin' if (ssl['session_cache']['builtin']['enable'] is defined and ssl['session_cache']['builtin']['enable'] is boolean and ssl['session_cache']['builtin']['enable'] | bool)) + (':' + ssl['session_cache']['builtin']['size'] | string) if ssl['session_cache']['builtin']['size'] is defined -}}
-{{- ('shared:' + ssl['session_cache']['shared']['name'] | string + ':' + ssl['session_cache']['shared']['size'] | string) if (ssl['session_cache']['shared']['name'] is defined and ssl['session_cache']['shared']['size'] is defined) }};
+{{- ('builtin' if ssl['session_cache']['builtin']['enable'] is defined and ssl['session_cache']['builtin']['enable'] is boolean and ssl['session_cache']['builtin']['enable'] | bool) + (':' + ssl['session_cache']['builtin']['size'] | string) if ssl['session_cache']['builtin']['size'] is defined -}}
+{{- ('shared:' + ssl['session_cache']['shared']['name'] | string + ':' + ssl['session_cache']['shared']['size'] | string) if ssl['session_cache']['shared']['name'] is defined and ssl['session_cache']['shared']['size'] is defined }};
 {% endif %}
 {% if ssl['session_ticket_key'] is defined and ssl['session_ticket_key'] is not mapping %}
 {% for key in ssl['session_ticket_key'] if ssl['session_ticket_key'] is not string %}

--- a/templates/http/upstream.j2
+++ b/templates/http/upstream.j2
@@ -13,13 +13,13 @@ upstream {{ upstream['name'] }} {
     {{- (' max_conns=' + server['max_conns'] | string) if server['max_conns'] is defined and server['max_conns'] is number -}}
     {{- (' max_fails=' + server['max_fails'] | string) if server['max_fails'] is defined and server['max_fails'] is number -}}
     {{- (' fail_timeout=' + server['fail_timeout'] | string) if server['fail_timeout'] is defined -}}
-    {{- ' backup' if server['backup'] is defined and server['backup'] is boolean -}}
-    {{- ' down' if server['down'] is defined and server['down'] is boolean -}}
-    {{- ' resolve' if server['resolve'] is defined and server['resolve'] is boolean -}}
+    {{- ' backup' if server['backup'] is defined and server['backup'] is boolean and server['backup'] | bool -}}
+    {{- ' down' if server['down'] is defined and server['down'] is boolean and server['down'] | bool -}}
+    {{- ' resolve' if server['resolve'] is defined and server['resolve'] is boolean and server['resolve'] | bool -}}
     {{- (' route=' + server['route'] | string) if server['route'] is defined -}}
     {{- (' service=' + server['service'] | string) if server['service'] is defined -}}
     {{- (' slow_start=' + server['slow_start'] | string) if server['slow_start'] is defined -}}
-    {{- ' drain' if server['drain'] is defined and server['drain'] is boolean }};
+    {{- ' drain' if server['drain'] is defined and server['drain'] is boolean and server['drain'] | bool }};
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -61,7 +61,7 @@ upstream {{ upstream['name'] }} {
 {% if upstream['resolver']['address'] is defined %}
     resolver {{ upstream['resolver']['address'] if upstream['resolver']['address'] is string else upstream['resolver']['address'] | join(' ') -}}
     {{- (' valid=' + upstream['resolver']['valid'] | string) if upstream['resolver']['valid'] is defined -}}
-    {{- (' ipv6=' + (upstream['resolver']['ipv6'] | ternary('on', 'off'))) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] is boolean -}}
+    {{- (' ipv6=' + upstream['resolver']['ipv6'] | ternary('on', 'off')) if upstream['resolver']['ipv6'] is defined and upstream['resolver']['ipv6'] is boolean -}}
     {{- (' status_zone=' + upstream['resolver']['status_zone'] | string) if upstream['resolver']['status_zone'] is defined }};
 {% endif %}
 {% if upstream['resolver_timeout'] is defined %}
@@ -71,19 +71,19 @@ upstream {{ upstream['name'] }} {
     sticky cookie {{ upstream['sticky_cookie']['name'] -}}
     {{- (' expires=' + upstream['sticky_cookie']['expires'] | string) if upstream['sticky_cookie']['expires'] is defined -}}
     {{- (' domain=' + upstream['sticky_cookie']['domain'] | string) if upstream['sticky_cookie']['domain'] is defined -}}
-    {{- ' httponly' if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] is boolean -}}
+    {{- ' httponly' if upstream['sticky_cookie']['httponly'] is defined and upstream['sticky_cookie']['httponly'] is boolean and upstream['sticky_cookie']['httponly'] | bool -}}
     {{- (' samesite' + upstream['sticky_cookie']['samesite'] | string) if upstream['sticky_cookie']['samesite'] is defined and upstream['sticky_cookie']['samesite'] in ['strict', 'lax', 'none'] -}}
-    {{- ' secure' if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] is boolean -}}
+    {{- ' secure' if upstream['sticky_cookie']['secure'] is defined and upstream['sticky_cookie']['secure'] is boolean and upstream['sticky_cookie']['secure'] | bool -}}
     {{- (' path=' + upstream['sticky_cookie']['path'] | string) if upstream['sticky_cookie']['path'] is defined }};
 {% elif upstream['sticky_route'] is defined %}
     sticky route {{ upstream['sticky_route'] if upstream['sticky_route'] is string else upstream['sticky_route'] | join(' ') }};
 {% elif upstream['sticky_learn'] is defined %}
     sticky learn {{ ('create=' + upstream['sticky_learn']['create'] | string) if upstream['sticky_learn']['create'] is string else ('create=' + upstream['sticky_learn']['create'] | join(' create=')) -}}
     {{- (' lookup=' + upstream['sticky_learn']['lookup'] | string) if upstream['sticky_learn']['lookup'] is string else (' lookup=' + upstream['sticky_learn']['lookup'] | join(' lookup=')) -}}
-    {{- ' zone=' + (upstream['sticky_learn']['zone']['name'] | string) + ':' + (upstream['sticky_learn']['zone']['size'] | string) -}}
+    {{- ' zone=' + upstream['sticky_learn']['zone']['name'] | string + ':' + upstream['sticky_learn']['zone']['size'] | string -}}
     {{- (' timeout=' + upstream['sticky_learn']['timeout'] | string) if upstream['sticky_learn']['timeout'] is defined -}}
-    {{- ' header' if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] is boolean -}}
-    {{- ' sync' if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] is boolean }};
+    {{- ' header' if upstream['sticky_learn']['header'] is defined and upstream['sticky_learn']['header'] is boolean and upstream['sticky_learn']['header'] | bool -}}
+    {{- ' sync' if upstream['sticky_learn']['sync'] is defined and upstream['sticky_learn']['sync'] is boolean and upstream['sticky_learn']['sync'] | bool }};
 {% endif %}
 }
 {% endif %}


### PR DESCRIPTION
### Proposed changes

* NGINX listen `so_keepalive` parameter was not working as intended when setting specific values.
* Make sure all template objects are properly transformed into strings before doing Jinja2 operations.
* Remove unnecessary parentheses.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
