### PR TITLE
Automatically create NGINX client body temp path directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Remove parameters deprecated in release `0.4.0`. To recap, these are `nginx_conf
 
 FEATURES:
 
-Add `backup` variable to template and upload parameters. Set to `false` if you don't want to keep backups of your previous NGINX config files.
+* Add `backup` variable to template and upload parameters. Set to `false` if you don't want to keep backups of your previous NGINX config files.
+* Automatically create a NGINX `client_body_temp_path` directory if your NGINX config uses the directive.
 
 ## 0.4.2 (October 28, 2021)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -131,7 +131,7 @@
                 client_body_in_file_only: false
                 client_body_in_single_buffer: false
                 client_body_temp_path:
-                  path: /var/cache/nginx
+                  path: /var/cache/nginx/client
                   level: 2
                 client_body_timeout: 60s
                 client_header_buffer_size: 1k

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -26,6 +26,20 @@
       register: this
       failed_when: "'Hello World' not in this.content"
 
+    - name: Check client body cache directory exists
+      stat:
+        path: /var/cache/nginx/client
+      check_mode: true
+      register: stat_result
+      failed_when: not stat_result.stat.exists
+
+    - name: Check proxy cache directory exists
+      stat:
+        path: /var/cache/nginx/proxy
+      check_mode: true
+      register: stat_result
+      failed_when: not stat_result.stat.exists
+
     - name: Check default.conf exists
       stat:
         path: /etc/nginx/conf.d/default.conf

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -45,15 +45,15 @@
 
 - name: Ensure NGINX client body cache directories exist
   file:
-    path: "{{ item.1.path }}"
+    path: "{{ item.config.core.client_body_temp_path.path }}"
     state: directory
     owner: "{{ nginx_config_main_template.user | default('nginx') }}"
     mode: 0755
-  with_subelements:
-    - "{{ nginx_config_http_template }}"
-    - config.core.client_body_temp_path
-    - skip_missing: true
-  when: nginx_config_http_template_enable | bool
+  loop:
+    "{{ nginx_config_http_template }}"
+  when:
+    - nginx_config_http_template_enable | bool
+    - item.config.core.client_body_temp_path.path is defined
 
 - name: Ensure NGINX proxy cache directories exist
   file:

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -43,6 +43,18 @@
   when: nginx_config_main_template_enable | bool
   notify: (Handler - NGINX Config) Run NGINX
 
+- name: Ensure NGINX client body cache directories exist
+  file:
+    path: "{{ item.1.path }}"
+    state: directory
+    owner: "{{ nginx_config_main_template.user | default('nginx') }}"
+    mode: 0755
+  with_subelements:
+    - "{{ nginx_config_http_template }}"
+    - config.core.client_body_temp_path
+    - skip_missing: true
+  when: nginx_config_http_template_enable | bool
+
 - name: Ensure NGINX proxy cache directories exist
   file:
     path: "{{ item.1.path }}"
@@ -53,7 +65,7 @@
     - "{{ nginx_config_http_template }}"
     - config.proxy.cache_path
     - skip_missing: true
-  when: nginx_config_main_template_enable | bool
+  when: nginx_config_http_template_enable | bool
 
 - name: Ensure NGINX HTTP directory exists
   file:


### PR DESCRIPTION
### Proposed changes

Automatically create a NGINX `client_body_temp_path` directory if your NGINX config uses the directive. Closes #89.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
