### PR TITLE
HTTP template: Fix bug with single custom_directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ FEATURES:
 
 Add `backup` variable to template and upload parameters. Set to `false` if you don't want to keep backups of your previous NGINX config files.
 
+BUG FIXES:
+
+Fix a bug when using a single `custom_directives` entry and the http template
+
 ## 0.4.2 (October 28, 2021)
 
 BUG FIXES:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -92,7 +92,7 @@
 {% for directive in item['config']['custom_directives'] if item['config']['custom_directives'] is not string %}
 {{ directive }}
 {% else %}
-{{ item['config']['custom_directive'] }}
+{{ item['config']['custom_directives'] }}
 {% endfor %}
 {% endif %}
 {% if item['config']['servers'] is defined %}
@@ -228,7 +228,7 @@ server {
    {{ directive }}
 {% endfilter %}
 {% else %}
-    {{ server['custom_directive'] }}
+    {{ server['custom_directives'] }}
 {% endfor %}
 {% endif %}
 {% if server['locations'] is defined %}
@@ -358,7 +358,7 @@ server {
         {{ directive }}
 {% endfilter %}
 {% else %}
-        {{ location['custom_directive'] }}
+        {{ location['custom_directives'] }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
### Proposed changes

this fixes the handling of single string based custom_directives in the http template.
without this, only a list of directives works because for single ones "custom_directive" is used inside a block that only works with "custom_directives" (with a plural s)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
