### PR TITLE
Fix typo in REST API template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ FEATURES:
 
 BUG FIXES:
 
-Fix a bug when using a single `custom_directives` entry and the http template
+* Fix a bug when using a single `custom_directives` entry and the http template.
+* Fix typo in the REST API template.
+* Fix incorrect REST API and status log variable names in [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml).
 
 ## 0.4.2 (October 28, 2021)
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -678,8 +678,8 @@ nginx_config_status_file_location: /etc/nginx/conf.d/status.conf
 nginx_config_status_backup: true
 nginx_config_status_port: 8080  # Optional -- Defaults to 8080
 nginx_config_status_access_log:  # Optional -- Set to 'false' and remove/comment nested variables to disable access log
-  location: /var/log/nginx/access.log  # Required
-  name: main  # Required
+  path: /var/log/nginx/access.log  # Required
+  format: main  # Required
 nginx_config_status_allow:  # Optional
   - 127.0.0.1
 nginx_config_status_deny:  # Optional
@@ -695,8 +695,8 @@ nginx_config_rest_api_backup: true
 nginx_config_rest_api_port: 8080  # Optional-- Defaults to 8080
 nginx_config_rest_api_write: false  # Optional
 nginx_config_rest_api_access_log:  # Optional -- Set to 'false' and remove/comment nested variables to disable access log
-  location: /var/log/nginx/access.log  # Required
-  name: main  # Required
+  path: /var/log/nginx/access.log  # Required
+  format: main  # Required
 nginx_config_rest_api_allow:  # Optional
   - 127.0.0.1
 nginx_config_rest_api_deny:  # Optional

--- a/templates/http/api.conf.j2
+++ b/templates/http/api.conf.j2
@@ -4,7 +4,7 @@
 server {
     listen {{ nginx_config_rest_api_port | default('8080') }};
 {% if nginx_config_rest_api_access_log is defined %}
-    access_log{{ ' off' if not nginx_config_rest_api_access_log }}{{ (' ' + nginx_config_rest_api_access_log['path']) if nginx_config_rest_api_access_log['path'] is defined }}{{ (' ' + nginx_config_rest_api_access_log['format']) if nginx_config_status_rest_api_log['format'] is defined }};
+    access_log{{ ' off' if not nginx_config_rest_api_access_log }}{{ (' ' + nginx_config_rest_api_access_log['path']) if nginx_config_rest_api_access_log['path'] is defined }}{{ (' ' + nginx_config_rest_api_access_log['format']) if nginx_config_rest_api_log['format'] is defined }};
 {% endif %}
     location /api {
 {% if nginx_config_rest_api_write is defined %}


### PR DESCRIPTION
### Proposed changes

* Fix typo in the REST API template.
* Fix incorrect REST API and status log variable names in [`defaults/main/template.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/template.yml).
* Fixes #208.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
