### PR TITLE
Ansible check mode fails if NGINX is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.5.0 (Unreleased)
+## 0.5.1 (Unreleased)
+
+BUG FIXES:
+
+Ansible check mode runs will no longer fail if NGINX has not yet been installed.
+
+## 0.5.0 (February 17, 2022)
 
 BREAKING CHANGES:
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,7 @@
   failed_when: config_check.rc != 0
   when:
     - config_check.stderr_lines is defined
+    - config_check.stderr_lines != []
     - config_check.rc != 0
   listen: (Handler - NGINX Config) Run NGINX
 


### PR DESCRIPTION
### Proposed changes

Ansible check mode runs will no longer fail if NGINX has not yet been installed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
