### PR TITLE
Rename modules to use Ansible FQCNs

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 4.4.0
+    version: 4.6.1
   - name: ansible.posix
     version: 1.3.0
   - name: community.docker
-    version: 2.1.1
+    version: 2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ FEATURES:
 
 Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
 
+ENHANCEMENTS:
+
+Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
+
 BUG FIXES:
 
 Ansible check mode runs will no longer fail if NGINX has not yet been installed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.1 (Unreleased)
 
+FEATURES:
+
+Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
+
 BUG FIXES:
 
 Ansible check mode runs will no longer fail if NGINX has not yet been installed.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -47,3 +47,8 @@ galaxy_info:
     - server
     - development
     - configuration
+
+collections:
+  - community.general
+  - ansible.builtin
+  - ansible.posix

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -49,6 +49,5 @@ galaxy_info:
     - configuration
 
 collections:
-  - community.general
-  - ansible.builtin
   - ansible.posix
+  - community.general

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -18,25 +18,25 @@
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Set SELinux mode to permissive
-  selinux:
+  ansible.posix.selinux:
     state: permissive
     policy: targeted
   when: not (ansible_check_mode and nginx_config_selinux_enforcing)
 
 - name: Allow SELinux HTTP network connections
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_connect
     state: true
     persistent: true
 
 - name: Allow SELinux HTTP network connections
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_relay
     state: true
     persistent: true
 
 - name: Allow SELinux TCP connections on status ports
-  seport:
+  community.general.selinux:
     ports: "{{ nginx_config_status_port }}"
     proto: tcp
     setype: http_port_t
@@ -44,7 +44,7 @@
   when: nginx_config_status_port is defined
 
 - name: Allow SELinux TCP connections on Rest API ports
-  seport:
+  community.general.selinux:
     ports: "{{ nginx_config_rest_api_port }}"
     proto: tcp
     setype: http_port_t
@@ -52,7 +52,7 @@
   when: nginx_config_rest_api_port is defined
 
 - name: Allow SELinux TCP connections on specific ports
-  seport:
+  community.general.selinux:
     ports: "{{ nginx_config_selinux_tcp_ports }}"
     proto: tcp
     setype: http_port_t
@@ -60,7 +60,7 @@
   when: nginx_config_selinux_tcp_ports is defined
 
 - name: Allow SELinux UDP connections on specific ports
-  seport:
+  community.general.selinux:
     ports: "{{ nginx_config_selinux_udp_ports }}"
     proto: udp
     setype: http_port_t
@@ -68,7 +68,7 @@
   when: nginx_config_selinux_udp_ports is defined
 
 - name: Set SELinux mode to enforcing
-  selinux:
+  ansible.posix.selinux:
     state: enforcing
     policy: targeted
   when: nginx_config_selinux_enforcing


### PR DESCRIPTION
### Proposed changes

* Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
