### PR TITLE
Use labels for loops in template-config to reduce amount of data in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Rename all modules to use the fully qualified collection name (FQCN) per Ansible
 
 ENHANCEMENTS:
 
-Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
+* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
+* Add labels to loops in `tasks/config/template-config.yml` to reduce amount of output data.
 
 BUG FIXES:
 

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -49,8 +49,9 @@
     state: directory
     owner: "{{ nginx_config_main_template.user | default('nginx') }}"
     mode: 0755
-  loop:
-    "{{ nginx_config_http_template }}"
+  loop: "{{ nginx_config_http_template | map(attribute='config') }}"
+  loop_control:
+    label: "{{ item.config.core.client_body_temp_path.path | default('config.core.client_body_temp_path.path undefined') }}"
   when:
     - nginx_config_http_template_enable | bool
     - item.config.core.client_body_temp_path.path is defined
@@ -73,6 +74,8 @@
     state: directory
     mode: 0755
   loop: "{{ nginx_config_http_template }}"
+  loop_control:
+    label: "{{ item.deployment_location | default('/etc/nginx/conf.d/') | dirname }}"
   when: nginx_config_http_template_enable | bool
 
 - name: Dynamically generate NGINX HTTP config files
@@ -82,6 +85,8 @@
     backup: "{{ item.backup  | default(true) }}"
     mode: 0644
   loop: "{{ nginx_config_http_template }}"
+  loop_control:
+    label: "{{ item.deployment_location | default('/etc/nginx/conf.d/default.conf') }}"
   when: nginx_config_http_template_enable | bool
   notify: (Handler - NGINX Config) Run NGINX
 
@@ -109,6 +114,8 @@
     state: directory
     mode: 0755
   loop: "{{ nginx_config_stream_template }}"
+  loop_control:
+    label: "{{ item.deployment_location | default('/etc/nginx/conf.d/') | dirname }}"
   when: nginx_config_stream_template_enable | bool
 
 - name: Dynamically generate NGINX stream config files
@@ -118,5 +125,7 @@
     backup: true
     mode: 0644
   loop: "{{ nginx_config_stream_template }}"
+  loop_control:
+    label: "{{ item.deployment_location | default('/etc/nginx/conf.d/stream_default.conf') }}"
   notify: (Handler - NGINX Config) Run NGINX
   when: nginx_config_stream_template_enable | bool

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -62,10 +62,9 @@
     state: directory
     owner: "{{ nginx_config_main_template.user | default('nginx') }}"
     mode: 0755
-  with_subelements:
-    - "{{ nginx_config_http_template }}"
-    - config.proxy.cache_path
-    - skip_missing: true
+  loop: "{{ nginx_config_http_template | subelements('config.proxy.cache_path', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.1.path | default('config.proxy.cache_path.path undefined') }}"
   when: nginx_config_http_template_enable | bool
 
 - name: Ensure NGINX HTTP directory exists

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -49,7 +49,7 @@
     state: directory
     owner: "{{ nginx_config_main_template.user | default('nginx') }}"
     mode: 0755
-  loop: "{{ nginx_config_http_template | map(attribute='config') }}"
+  loop: "{{ nginx_config_http_template }}"
   loop_control:
     label: "{{ item.config.core.client_body_temp_path.path | default('config.core.client_body_temp_path.path undefined') }}"
   when:


### PR DESCRIPTION
### Proposed changes

Current tasks including loop, do not use labels. Thus, at the output we can see all the data of the loops items.
This little PR adds labels to tasks inside `template-config.yml`. 
Some label defaults have been taken from tasks content.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
