### PR TITLE
Improve the NGINX main config defaults (2nd try)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.2 (Unreleased)
+
+BUG FIXES:
+
+Improve the NGINX main config defaults to bring them closer to the standard NGINX defaults on a fresh NGINX install.
+
 ## 0.5.1 (April 6, 2022)
 
 FEATURES:

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -17,8 +17,8 @@ nginx_config_main_template:
   backup: true
   config:
     main:  # Configure NGINX main core directives
-      load_module: modules/ngx_http_js_module.so  # String or a list of strings
-        # - modules/ngx_http_js_module.so
+      # load_module: modules/ngx_http_js_module.so  # String or a list of strings
+      #   - modules/ngx_http_js_module.so
       user:  # nginx  # Can alternatively be set to a 'username' string
         username: nginx  # Required
         group: nginx
@@ -66,9 +66,9 @@ nginx_config_main_template:
       worker_connections: 1024  # Number
     http:
       include: /etc/nginx/conf.d/*.conf  # String or a list of strings
-    stream:
-      include:  # String or a list of strings
-        - /etc/nginx/conf.d/stream/*.conf
+    # stream:
+    #   include:  # String or a list of strings
+    #     - /etc/nginx/conf.d/stream/*.conf
 
 # Enable creating dynamic templated NGINX HTTP configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -65,7 +65,9 @@ nginx_config_main_template:
       # worker_aio_requests: 32  # Number
       worker_connections: 1024  # Number
     http:
-      include: /etc/nginx/conf.d/*.conf  # String or a list of strings
+      include:  # String or a list of strings
+        - /etc/nginx/mime.types
+        - /etc/nginx/conf.d/*.conf
     # stream:
     #   include:  # String or a list of strings
     #     - /etc/nginx/conf.d/stream/*.conf


### PR DESCRIPTION
### Proposed changes

Improve the NGINX main config defaults to bring them closer to the standard NGINX defaults on a fresh NGINX install (part 2 after #252).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
