### PR TITLE
Support the latest NGINX Plus R26 directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ENHANCEMENTS:
 
-Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+* Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+* Add support for the latest NGINX Plus R26 directives:
+  * `auth_jwt_require` now allows you to optionally set the `error` code you wish to return.
+  * `health_check` now lets you set a `keepalive_time`.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -68,43 +68,43 @@ The NGINX config Ansible role supports all platforms supported by [NGINX Open So
 
 ```yaml
 Alpine:
-  - 3.11
-  - 3.12
   - 3.13
   - 3.14
+  - 3.15
+  - 3.16
 Amazon Linux:
   - 2
 CentOS:
   - 7.4+
-  - 8
 Debian:
   - buster (10)
   - bullseye (11)
 Red Hat:
   - 7.4+
   - 8
+  - 9
 SUSE/SLES:
   - 12
   - 15
 Ubuntu:
   - bionic (18.04)
   - focal (20.04)
-  - hirsute (21.04)
+  - impish (21.10)
+  - jammy (22.04)
 ```
 
 ### NGINX Plus
 
 ```yaml
 Alpine:
-  - 3.11
-  - 3.12
   - 3.13
   - 3.14
+  - 3.15
+  - 3.16
 Amazon Linux 2:
   - any
 CentOS:
   - 7.4+
-  - 8
 Debian:
   - buster (10)
   - bullseye (11)
@@ -116,12 +116,14 @@ Oracle Linux:
 Red Hat:
   - 7.4+
   - 8
+  - 9
 SUSE/SLES:
   - 12
   - 15
 Ubuntu:
   - bionic (18.04)
   - focal (20.04)
+  - jammy (22.04)
 ```
 
 ## Role Variables

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -529,7 +529,9 @@ nginx_config_http_template:
         key_request: /path/to/file
         leeway: 0s
         type: signed  # Can be set to 'signed', 'encrypted' or 'nested'
-        require: $valid_jwt_iss  # String or a list of strings
+        require:
+          values: $valid_jwt_iss  # Required -- String or a list of strings
+          error: 401  # Can be set to '401' or '403'
       api:  # Available only in NGINX Plus -- Configure HTTP API
         enable:  # true  # Set to Boolean directly to simply enable the 'api' directive -- Available only in the 'location' context
           write: true  # Boolean
@@ -582,6 +584,7 @@ nginx_config_http_template:
             port: 80
             grpc_service: service
             grpc_status: 12
+            keepalive_time: 0
         match:  # Available only in the 'http' context
           - name: name  # Required
             conditions: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,7 @@ galaxy_info:
       versions:
         - '7'
         - '8'
+        - '9'
     - name: FreeBSD
       versions:
         - '12.1'
@@ -31,7 +32,8 @@ galaxy_info:
       versions:
         - bionic
         - focal
-        - hirsute
+        - impish
+        - jammy
     - name: SLES
       versions:
         - '12'

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -213,7 +213,9 @@
                   name: info
                 leeway: 0s
                 type: nested
-                require: jwt
+                require:
+                  values: jwt
+                  error: 403
               auth_request:
                 uri: false
                 set:
@@ -416,6 +418,7 @@
                             persistent: false
                             match: nginx
                             port: 80
+                            keepalive_time: 0
                       proxy:
                         bind: false
                         buffer_size: 4k

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -214,7 +214,7 @@
                 leeway: 0s
                 type: nested
                 require:
-                  values: jwt
+                  values: $jwt_claim_iss
                   error: 403
               auth_request:
                 uri: false

--- a/templates/http/auth.j2
+++ b/templates/http/auth.j2
@@ -74,7 +74,7 @@ auth_jwt_leeway {{ auth_jwt['leeway'] }};
 auth_jwt_type {{ auth_jwt['type'] }};
 {% endif %}
 {% if auth_jwt['require'] is defined %}
-auth_jwt_require {{ auth_jwt['require'] if auth_jwt['require'] is string else auth_jwt['require'] | join(' ') }};
+auth_jwt_require {{ auth_jwt['require']['values'] if auth_jwt['require']['values'] is string else auth_jwt['require']['values'] | join(' ') }}{{ (' ' + auth_jwt['require']['error'] | string) if auth_jwt['require']['error'] in ['401', '403'] }};
 {% endif %}
 
 {% endmacro %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -118,7 +118,8 @@ health_check{{ (' interval=' + health_check['interval'] | string) if health_chec
 {{- (' port=' + health_check['port'] | string) if health_check['port'] is defined -}}
 {{- ' type=grpc' if health_check['grpc_service'] is defined or health_check['grpc_status'] is defined -}}
 {{- (' grpc_service=' + health_check['grpc_service'] | string) if health_check['grpc_service'] is defined -}}
-{{- (' grpc_status=' + health_check['grpc_status'] | string) if health_check['grpc_status'] is defined }};
+{{- (' grpc_status=' + health_check['grpc_status'] | string) if health_check['grpc_status'] is defined -}}
+{{- (' keepalive_time=' + health_check['keepalive_time'] | string) if health_check['keepalive_time'] is defined }};
 {% endfor %}
 {% endif %}
 {% if health_check['match'] is defined and health_check['match'] is not string and health_check['match'] is not mapping %}{# 'match' directive is only available in the 'http' context #}


### PR DESCRIPTION
### Proposed changes

* `auth_jwt_require` now allows you to optionally set the `error` code you wish to return
* `health_check` now lets you set a `keepalive_time`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
