### PR TITLE
Bump Ansible collections

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
+offline: true
 skip_list:
   - yaml[line-length]

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 5.1.1
+    version: 5.5.0
   - name: ansible.posix
     version: 1.4.0
   - name: community.docker
-    version: 2.6.0
+    version: 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ENHANCEMENTS:
 
-* Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+* Bump the Ansible `community.general` collection to `5.5.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `3.1.0`.
 * Add support for the latest NGINX Plus R26 directives:
   * `auth_jwt_require` now allows you to optionally set the `error` code you wish to return.
   * `health_check` now lets you set a `keepalive_time`.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This role configures NGINX Open Source and NGINX Plus on your target host.
     ---
     collections:
       - name: community.general
-        version: 5.1.1
+        version: 5.5.0
       - name: ansible.posix
         version: 1.4.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 2.6.0
+        version: 3.1.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.

--- a/molecule/plus/prepare.yml
+++ b/molecule/plus/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../common/files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../common/files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -11,7 +11,7 @@
   ansible.builtin.template:
     src: "{{ item.template_file | default('www/index.html.j2') }}"
     dest: "{{ item.deployment_location | default('/usr/share/nginx/html/index.html') }}"
-    backup: "{{ item.backup  | default(true) }}"
+    backup: "{{ item.backup | default(true) }}"
     mode: 0644
   loop: "{{ nginx_config_html_demo_template }}"
   when: nginx_config_html_demo_template_enable | bool
@@ -38,7 +38,7 @@
   ansible.builtin.template:
     src: "{{ nginx_config_main_template.template_file | default('nginx.conf.j2') }}"
     dest: "{{ nginx_config_main_template.deployment_location | default('/etc/nginx/nginx.conf') }}"
-    backup: "{{ nginx_config_main_template.backup  | default(true) }}"
+    backup: "{{ nginx_config_main_template.backup | default(true) }}"
     mode: 0644
   when: nginx_config_main_template_enable | bool
   notify: (Handler - NGINX Config) Run NGINX
@@ -81,7 +81,7 @@
   ansible.builtin.template:
     src: "{{ item.template_file | default('http/default.conf.j2') }}"
     dest: "{{ item.deployment_location | default('/etc/nginx/conf.d/default.conf') }}"
-    backup: "{{ item.backup  | default(true) }}"
+    backup: "{{ item.backup | default(true) }}"
     mode: 0644
   loop: "{{ nginx_config_http_template }}"
   loop_control:

--- a/tasks/config/upload-config.yml
+++ b/tasks/config/upload-config.yml
@@ -44,7 +44,7 @@
         path: "{{ item.dest }}"
         state: directory
         mode: 0755
-      loop: "{{ nginx_config_upload_ssl_crt +  nginx_config_upload_ssl_key }}"
+      loop: "{{ nginx_config_upload_ssl_crt + nginx_config_upload_ssl_key }}"
 
     - name: Upload NGINX SSL certificates
       ansible.builtin.copy:


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `5.5.0` and `community.docker` collection to `3.1.0`, and address Linter warnings.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
