### PR TITLE
Support the latest NGINX App Protect DoS directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * Add support for the latest NGINX Plus R26 directives:
   * `auth_jwt_require` now allows you to optionally set the `error` code you wish to return.
   * `health_check` now lets you set a `keepalive_time`.
+* Add support for the latest NGINX App Protect DoS directives (`app_protect_dos_arb_fqdn`, `app_protect_dos_api`, and `app_protect_dos_accelerated_mitigation`).
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -348,6 +348,9 @@ nginx_config_http_template:
           enable: true  # Required
           uri: example.com
           port: 80
+        arb_fqdn: 192.168.1.10  # Available only in the 'http' context
+        api: false  # Available only in the 'location' context
+        accelerated_mitigation: false  # Available only in the 'http' context
       proxy:  # Configure proxy settings
         bind:  # Set to 'false' and remove/comment nested variables to disable proxy_bind
           address: 0.0.0.0  # Required

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -161,6 +161,17 @@
                 failure_mode_action: pass
                 cookie_seed: testseed
                 compressed_requests_action: drop
+              app_protect_dos:
+                liveliness:
+                  enable: true
+                  uri: /app_protect_dos_liveliness
+                  port: 8090
+                readiness:
+                  enable: true
+                  uri: /app_protect_dos_readiness
+                  port: 8090
+                arb_fqdn: 192.168.1.10
+                accelerated_mitigation: false
               grpc:
                 bind:
                   address: $remote_addr
@@ -396,6 +407,7 @@
                           path: /etc/app_protect_dos/log-default.json
                           dest: syslog:server=10.1.1.1:514
                         monitor: http://10.1.1.1:5000/monitor
+                        api: true
                       auth_jwt:
                         enable: false
                         leeway: 0s

--- a/templates/http/app_protect.j2
+++ b/templates/http/app_protect.j2
@@ -17,9 +17,6 @@ app_protect_cookie_seed {{ app_protect_waf['cookie_seed'] }};
 {% if app_protect_waf['compressed_requests_action'] is defined and app_protect_waf['compressed_requests_action'] in ['pass', 'drop'] %}{# 'app_protect_compressed_requests_action' directive is only available in the 'http' context #}
 app_protect_compressed_requests_action {{ app_protect_waf['compressed_requests_action'] }};
 {% endif %}
-{% if app_protect_waf['reconnect_period_seconds'] is defined and app_protect_waf['reconnect_period_seconds'] is number %}{# 'app_protect_reconnect_period_seconds' directive is only available in the 'http' context #}
-app_protect_reconnect_period_seconds {{ app_protect_waf['reconnect_period_seconds'] }};
-{% endif %}
 {% if app_protect_waf['request_buffer_overflow_action'] is defined and app_protect_waf['request_buffer_overflow_action'] in ['pass', 'drop'] %}{# 'app_protect_request_buffer_overflow_action' directive is only available in the 'http' context #}
 app_protect_request_buffer_overflow_action {{ app_protect_waf['request_buffer_overflow_action'] }};
 {% endif %}
@@ -29,6 +26,9 @@ app_protect_user_defined_signatures {{ signature }};
 {% else %}
 app_protect_user_defined_signatures {{ app_protect_waf['user_defined_signatures'] }};
 {% endfor %}
+{% endif %}
+{% if app_protect_waf['reconnect_period_seconds'] is defined and app_protect_waf['reconnect_period_seconds'] is number %}{# 'app_protect_reconnect_period_seconds' directive is only available in the 'http' context #}
+app_protect_reconnect_period_seconds {{ app_protect_waf['reconnect_period_seconds'] }};
 {% endif %}
 {% if app_protect_waf['enable'] is defined and app_protect_waf['enable'] is boolean %}
 app_protect_enable {{ app_protect_waf['enable'] | ternary('on', 'off') }};
@@ -73,7 +73,16 @@ app_protect_dos_security_log {{ app_protect_dos['security_log']['path'] }} {{ ap
 app_protect_dos_liveness {{ app_protect_dos['liveness']['enable'] | ternary('on', 'off') }}{{ (' uri:' + app_protect_dos['liveness']['uri'] | string) if app_protect_dos['liveness']['uri'] is defined }}{{ (' port:' + app_protect_dos['liveness']['port'] | string) if app_protect_dos['liveness']['port'] is defined }};
 {% endif %}
 {% if app_protect_dos['readiness']['enable'] is defined and app_protect_dos['readiness'] is boolean %}{# 'app_protect_dos_readiness' directive is only available in the 'http' context #}
-app_protect_dos_readiness {{ app_protect_dos['readiness'] | ternary('on', 'off') }}{{ (' uri:' + app_protect_dos['readiness']['uri'] | string) if app_protect_dos['readiness']['uri'] is defined }}{{ (' port:' + app_protect_dos['readiness']['port'] | string) if app_protect_dos['readiness']['port'] is defined }};
+app_protect_dos_readiness {{ app_protect_dos['readiness']['enable'] | ternary('on', 'off') }}{{ (' uri:' + app_protect_dos['readiness']['uri'] | string) if app_protect_dos['readiness']['uri'] is defined }}{{ (' port:' + app_protect_dos['readiness']['port'] | string) if app_protect_dos['readiness']['port'] is defined }};
+{% endif %}
+{% if app_protect_dos['arb_fqdn'] is defined %}{# 'app_protect_dos_arb_fqdn' directive is only available in the 'http' context #}
+app_protect_dos_arb_fqdn {{ app_protect_dos['arb_fqdn'] }};
+{% endif %}
+{% if app_protect_dos['api'] is defined and app_protect_dos['api'] is boolean and app_protect_dos['api'] | bool %}{# 'app_protect_dos_api' directive is only available in the 'location' context #}
+app_protect_dos_api;
+{% endif %}
+{% if app_protect_dos['accelerated_mitigation'] is defined and app_protect_dos['accelerated_mitigation'] is boolean %}{# 'app_protect_dos_accelerated_mitigation' directive is only available in the 'http' context #}
+app_protect_dos_accelerated_mitigation {{ app_protect_dos['accelerated_mitigation'] | ternary('on', 'off') }};
 {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
### Proposed changes

Add support for the latest NGINX App Protect DoS directives (`app_protect_dos_arb_fqdn`, `app_protect_dos_api`, and `app_protect_dos_accelerated_mitigation`).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
