### PR TITLE
Fix system user usage in template-config

### DIFF
--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -47,7 +47,7 @@
   ansible.builtin.file:
     path: "{{ item.config.core.client_body_temp_path.path }}"
     state: directory
-    owner: "{{ nginx_config_main_template.user | default('nginx') }}"
+    owner: "{{ nginx_config_main_template.config.main.user.username | default('nginx') }}"
     mode: 0755
   loop: "{{ nginx_config_http_template }}"
   loop_control:
@@ -60,7 +60,7 @@
   ansible.builtin.file:
     path: "{{ item.1.path }}"
     state: directory
-    owner: "{{ nginx_config_main_template.user | default('nginx') }}"
+    owner: "{{ nginx_config_main_template.config.main.user.username | default('nginx') }}"
     mode: 0755
   loop: "{{ nginx_config_http_template | subelements('config.proxy.cache_path', skip_missing=True) }}"
   loop_control:


### PR DESCRIPTION
### Proposed changes

Fix the system user usage for checking the client body cache and proxy cache directories. When the structure of the `nginx_config_main_template` changed and the system user name was moved deeper into the structure, the two tasks to check the ownership of the client body cache and proxy cache did not get adjusted.

I am not proficient enough with molecule to add molecule tests for this, maybe someone can help with that? 
