### PR TITLE
Fix tests not running on external PRs

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,6 +16,9 @@ jobs:
   molecule:
     name: Molecule
     runs-on: ubuntu-20.04
+    env:
+      NGINX_CRT: ${{ secrets.NGINX_CRT }}
+      NGINX_KEY: ${{ secrets.NGINX_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,24 +29,26 @@ jobs:
           - stable_push
     steps:
       - name: Check out the codebase
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/checkout@v3
 
       - name: Set up Python 3
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
       - name: Install Molecule dependencies
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: pip3 install -r .github/workflows/requirements/requirements_molecule.txt
 
       - name: Install Ansible core dependencies
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
       - name: Run Molecule tests
-        if: ${{ env.NGINX_CRT != 0 && env.NGINX_KEY != 0 }}
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: molecule test -s ${{ matrix.scenario }}
         env:
           PY_COLORS: 1
           ANSIBLE_FORCE_COLOR: 1
-          NGINX_CRT: ${{ secrets.NGINX_CRT }}
-          NGINX_KEY: ${{ secrets.NGINX_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.3 (Unreleased)
+
+BUG FIXES:
+
+GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
+
 ## 0.5.2 (October 17, 2022)
 
 ENHANCEMENTS:


### PR DESCRIPTION
### Proposed changes

GitHub actions should now correctly skip *plus* scenarios only when the NGINX Plus license secrets are not present.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
