### PR TITLE
Use `amd64` platform for Molecule tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX 
 
 TESTS:
 
-Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
+* Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
+* Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
 
 ## 0.5.2 (October 17, 2022)
 

--- a/molecule/cleanup_module/molecule.yml
+++ b/molecule/cleanup_module/molecule.yml
@@ -11,6 +11,7 @@ lint: |
 platforms:
   - name: alpine-3.17
     image: alpine:3.17
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -19,6 +20,7 @@ platforms:
     command: /sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -27,6 +29,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -35,6 +38,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,7 @@ lint: |
 platforms:
   - name: alpine-3.17
     image: alpine:3.17
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -19,6 +20,7 @@ platforms:
     command: /sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -27,6 +29,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -35,6 +38,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -11,6 +11,7 @@ lint: |
 platforms:
   - name: centos-7
     image: centos:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -19,6 +20,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable_push/molecule.yml
+++ b/molecule/stable_push/molecule.yml
@@ -11,6 +11,7 @@ lint: |
 platforms:
   - name: alpine-3.17
     image: alpine:3.17
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -19,6 +20,7 @@ platforms:
     command: /sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -27,6 +29,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -35,6 +38,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
### Proposed changes

Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
