### PR TITLE
Replace non-existent GitHub actions key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Main global owner #
 #####################
-
 * @alessfg
 /.github/workflows/
 *.md

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,6 +1,6 @@
 ---
 name: Ansible Galaxy import
-"on":
+on:
   release:
     types:
       - published

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,14 +1,14 @@
 ---
 name: Molecule CI/CD
-"on":
+on:
   pull_request:
     branches:
       - main
   push:
     branches:
       - main
-    ignore-tags:
-      - "*"
+    tags-ignore:
+      - "**"
   schedule:
     - cron: "0 0 1 * *"
   workflow_dispatch:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
 name: Release Drafter
-"on":
+on:
   pull_request:
     types:
       - opened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ENHANCEMENTS:
 
+* Bump the minimum version of Ansible core required to run the role to `2.12` (`2.11` is no longer supported by Ansible).
 * Support the `include` directive in the main NGINX context.
 * Bump the Ansible `community.general` collection to `6.2.0` and `community.docker` collection to `3.4.0`.
 
 BUG FIXES:
 
-GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
+* GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
+* The `ignore-tags` GitHub actions key does not exist. Replace it with the correct key, `tags-ignore`.
 
 TESTS:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,36 +7,23 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: "2.11"
+  min_ansible_version: "2.12"
 
   platforms:
     - name: Alpine
-      versions:
-        - all
+      versions: [all]
     - name: Amazon Linux 2
-      versions:
-        - all
+      versions: [all]
     - name: Debian
-      versions:
-        - bullseye
+      versions: [bullseye]
     - name: EL
-      versions:
-        - "7"
-        - "8"
-        - "9"
+      versions: ['7', '8', '9']
     - name: FreeBSD
-      versions:
-        - "12.1"
+      versions: ['12.1']
     - name: Ubuntu
-      versions:
-        - bionic
-        - focal
-        - impish
-        - jammy
+      versions: [bionic, focal, impish, jammy]
     - name: SLES
-      versions:
-        - "12"
-        - "15"
+      versions: ['12', '15']
 
   galaxy_tags:
     - nginx


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

Bump the minimum version of Ansible core required to run the role to `2.12` (`2.11` is no longer supported by Ansible).

BUG FIXES:

The `ignore-tags` GitHub actions key does not exist. Replace it with the correct key, `tags-ignore`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
