### PR TITLE
Update NGINX role versions used by Molecule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
 * Explicitly specify `amd64` as the platform used in NGINX Plus Molecule tests. This will ensure that tests involving NGINX App Protect will work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
+* Update the versions of the Ansible NGINX and NGINX App Protect roles used by Molecule.
 
 ## 0.5.2 (October 17, 2022)
 

--- a/molecule/common/requirements/oss_requirements.yml
+++ b/molecule/common/requirements/oss_requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.23.2
+    version: 0.24.0

--- a/molecule/common/requirements/plus_requirements.yml
+++ b/molecule/common/requirements/plus_requirements.yml
@@ -1,6 +1,6 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.23.2
+    version: 0.24.0
   - name: nginxinc.nginx_app_protect
-    version: 0.8.1
+    version: 0.9.0


### PR DESCRIPTION
### Proposed changes

Update the versions of the Ansible NGINX and NGINX App Protect roles used by Molecule.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
