### PR TITLE
Change mappings value to a list in the default template

### DIFF
--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -647,14 +647,14 @@ nginx_config_http_template:
       map:  # Configure maps -- Available only in the 'http' context
         hash_bucket_size: 64
         hash_max_size: 2048
-        mappings:  # Dictionary or list of dictionaries
-          string: $remote_addr  # Required
-          variable: $upstream  # Required
-          hostnames: false  # Boolean
-          volatile: false  # Boolean
-          content:  # Dictionary or list of dictionaries
-            - value: default
-              new_value: 0
+        mappings:  # List of dictionaries
+          - string: $remote_addr  # Required
+            variable: $upstream  # Required
+            hostnames: false  # Boolean
+            volatile: false  # Boolean
+            content:  # Dictionary or list of dictionaries
+              - value: default
+                new_value: 0
       mirror:  # Configure mirrors
         request_body: true  # Boolean
         uri: false  # String or a list of strings -- Can alternatively be set to 'false'


### PR DESCRIPTION

### Proposed changes

The current default template states that the `mappings` value of the `map` directive expects a dictionary or a list of dictionaries, while in reality, it works only with a list. As adding secondary support for a single dictionary looks like overkill, I propose to change the template, so both the demo value and a comment reflect that `mappings` should be used with a list of dictionaries.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
