### PR TITLE
Drop log unsupported "spdy", make "http2" a server level option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## 0.6.1 (Unreleased)
 
+BREAKING CHANGES:
+
+- `spdy` parameter `listen` is removed
+- `http2` parameter for `listen` is removed
+
 ENHANCEMENTS:
 
 - Bump the Ansible `community.general` collection to `7.1.0`, `ansible.posix` collection to `1.5.4`, `community.crypto` collection to `2.14.0`, and `community.docker` collection to `3.4.7`.
+- Options from `http_v2` module are implemented.
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -274,9 +274,9 @@ nginx_config_http_template:
       http2:  # Configure HTTP2
         enable: false
         body_preread_size: 64k
-        chunk_size: 8k # can be used in a 'location' context
+        chunk_size: 8k
         max_concurrent_streams: 128
-        recv_buffer_size: 256k  # Available only in the 'http' context
+        recv_buffer_size: 256k
         recv_timeout: 20s
       ssl:  # Configure SSL
         buffer_size: 16k

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -271,7 +271,7 @@ nginx_config_http_template:
         underscores_in_headers: false  # Boolean -- Not available in the 'location' context
         variables_hash_bucket_size: 64  # Available only in the 'http' context
         variables_hash_max_size: 1024  # Available only in the 'http' context
-      http2: # all options are for 'http' or 'server' contexts only unless noted otherwise
+      http2:  # Configure HTTP2
         enable: false
         body_preread_size: 64k
         chunk_size: 8k # can be used in a 'location' context

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -217,7 +217,6 @@ nginx_config_http_template:
               keepidle: 30m
               keepintvl: 5
               keepcnt: 10
-        http2: false  # Boolean
         log_not_found: true  # Boolean
         log_subrequest: false  # Boolean
         max_ranges: 0  # Number
@@ -272,6 +271,13 @@ nginx_config_http_template:
         underscores_in_headers: false  # Boolean -- Not available in the 'location' context
         variables_hash_bucket_size: 64  # Available only in the 'http' context
         variables_hash_max_size: 1024  # Available only in the 'http' context
+      http2: # all options are for 'http' or 'server' contexts only unless noted otherwise
+        enable: false
+        body_preread_size: 64k
+        chunk_size: 8k # can be used in a 'location' context
+        max_concurrent_streams: 128
+        recv_buffer_size: 256k # 'http' level only
+        recv_timeout: 20s
       ssl:  # Configure SSL
         buffer_size: 16k
         certificate: /path/to/file  # String or a list of strings

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -204,8 +204,6 @@ nginx_config_http_template:
             port: 80
             default_server: true  # Boolean
             ssl: false  # Boolean
-            http2: false  # Boolean
-            spdy: false  # Boolean
             proxy_protocol: false  # Boolean
             fastopen: 12  # Number
             backlog: 511  # Number
@@ -219,6 +217,7 @@ nginx_config_http_template:
               keepidle: 30m
               keepintvl: 5
               keepcnt: 10
+        http2: false  # Boolean
         log_not_found: true  # Boolean
         log_subrequest: false  # Boolean
         max_ranges: 0  # Number

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -276,7 +276,7 @@ nginx_config_http_template:
         body_preread_size: 64k
         chunk_size: 8k # can be used in a 'location' context
         max_concurrent_streams: 128
-        recv_buffer_size: 256k # 'http' level only
+        recv_buffer_size: 256k  # Available only in the 'http' context
         recv_timeout: 20s
       ssl:  # Configure SSL
         buffer_size: 16k

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -229,6 +229,13 @@
                 underscores_in_headers: false
                 variables_hash_bucket_size: 64
                 variables_hash_max_size: 1024
+              http2:
+                enable: on
+                body_preread_size: 128k
+                chunk_size: 8k
+                max_concurrent_streams: 31
+                recv_buffer_size: 128k
+                recv_timeout: 10s
               ssl:
                 buffer_size: 16k
                 certificate: /etc/ssl/certs/molecule.crt
@@ -576,6 +583,9 @@
                     try_files:
                       files: $uri
                       uri: /images/default.gif
+                  http2:
+                    enable: off
+                    chunk_size: 8k
                   auth_basic:
                     realm: false
                   log:
@@ -652,6 +662,8 @@
                       core:
                         index: frontend_index.html
                         root: /usr/share/nginx/html
+                      http2:
+                        chunk_size: 8k
                     - location: /alias
                       core:
                         alias: /usr/share/nginx/html

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -230,7 +230,7 @@
                 variables_hash_bucket_size: 64
                 variables_hash_max_size: 1024
               http2:
-                enable: on
+                enable: true
                 body_preread_size: 128k
                 chunk_size: 8k
                 max_concurrent_streams: 31
@@ -550,7 +550,6 @@
                     aio:
                       threads: default
                     keepalive_timeout: 75s
-                    http2: false
                     listen:
                       - address: 0.0.0.0
                         port: 80
@@ -584,7 +583,7 @@
                       files: $uri
                       uri: /images/default.gif
                   http2:
-                    enable: off
+                    enable: false
                     chunk_size: 8k
                   auth_basic:
                     realm: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -543,13 +543,12 @@
                     aio:
                       threads: default
                     keepalive_timeout: 75s
+                    http2: false
                     listen:
                       - address: 0.0.0.0
                         port: 80
                         default_server: true
                         ssl: false
-                        http2: false
-                        spdy: false
                         proxy_protocol: false
                         fastopen: 12
                         backlog: 511

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -662,7 +662,7 @@
                         index: frontend_index.html
                         root: /usr/share/nginx/html
                       http2:
-                        chunk_size: 8k
+                        chunk_size: 10k
                     - location: /alias
                       core:
                         alias: /usr/share/nginx/html

--- a/templates/http/core.j2
+++ b/templates/http/core.j2
@@ -141,7 +141,6 @@ lingering_timeout {{ core['lingering_timeout'] }};
 listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if listen['address'] is defined and listen['port'] is defined }}{{ listen['port'] if listen['port'] is defined -}}
 {{- ' default_server' if listen['default_server'] is defined and listen['default_server'] is boolean and listen['default_server'] | bool -}}
 {{- ' ssl' if listen['ssl'] is defined and listen['ssl'] is boolean and listen['ssl'] | bool -}}
-{{- ' http2' if listen['http2'] is defined and listen['http2'] is boolean and listen['http2'] | bool else ' spdy' if listen['spdy'] is defined and listen['spdy'] is boolean and listen['spdy'] | bool -}}
 {{- ' proxy_protocol' if listen['proxy_protocol'] is defined and listen['proxy_protocol'] is boolean and listen['proxy_protocol'] | bool -}}
 {{- (' setfib=' + listen['setfib'] | string) if listen['setfib'] is defined -}}
 {{- (' fastopen=' + listen['fastopen'] | string) if listen['fastopen'] is defined and listen['fastopen'] is number -}}
@@ -156,6 +155,9 @@ listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if listen['
 {{- (' so_keepalive=' + listen['so_keepalive'] | ternary('on', 'off')) if listen['so_keepalive'] is defined and listen['so_keepalive'] is boolean -}}
 {{- (' so_keepalive=' + (listen['so_keepalive']['keepidle'] | string if listen['so_keepalive']['keepidle'] is defined) + ':' + (listen['so_keepalive']['keepintvl'] | string if listen['so_keepalive']['keepintvl'] is defined) + ':' + (listen['so_keepalive']['keepcnt'] | string if listen['so_keepalive']['keepcnt'] is defined)) if listen['so_keepalive'] is defined and listen['so_keepalive'] is mapping }};
 {% endfor %}
+{% endif %}
+{% if core['http2'] is defined and core['http2'] is boolean and core['http2'] | bool %}
+http2;
 {% endif %}
 {% if core['log_not_found'] is defined and core['log_not_found'] is boolean %}
 log_not_found {{ core['log_not_found'] | ternary('on', 'off') }};

--- a/templates/http/core.j2
+++ b/templates/http/core.j2
@@ -156,9 +156,6 @@ listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if listen['
 {{- (' so_keepalive=' + (listen['so_keepalive']['keepidle'] | string if listen['so_keepalive']['keepidle'] is defined) + ':' + (listen['so_keepalive']['keepintvl'] | string if listen['so_keepalive']['keepintvl'] is defined) + ':' + (listen['so_keepalive']['keepcnt'] | string if listen['so_keepalive']['keepcnt'] is defined)) if listen['so_keepalive'] is defined and listen['so_keepalive'] is mapping }};
 {% endfor %}
 {% endif %}
-{% if core['http2'] is defined and core['http2'] is boolean and core['http2'] | bool %}
-http2;
-{% endif %}
 {% if core['log_not_found'] is defined and core['log_not_found'] is boolean %}
 log_not_found {{ core['log_not_found'] | ternary('on', 'off') }};
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -8,6 +8,10 @@
 {% from 'http/core.j2' import core with context %}
 {{ core(item['config']['core']) }}
 {%- endif %}
+{% if item['config']['http2'] is defined %}
+{% from 'http/modules.j2' import http2 with context %}
+{{ http2(item['config']['http2'], 'http') }}
+{%- endif %}
 {% if item['config']['ssl'] is defined %}
 {% from 'http/ssl.j2' import ssl with context %}
 {{ ssl(item['config']['ssl']) }}
@@ -122,6 +126,12 @@ server {
 {% from 'http/core.j2' import core with context %}
 {% filter indent(4) %}
     {{ core(server['core']) }}
+{%- endfilter %}
+{% endif %}
+{% if server['http2'] is defined %}
+{% from 'http/modules.j2' import http2 with context %}
+{% filter indent(4) %}
+    {{ http2(server['http2'], 'server') }}
 {%- endfilter %}
 {% endif %}
 {% if server['ssl'] is defined %}
@@ -276,6 +286,12 @@ server {
 {% from 'http/core.j2' import core with context %}
 {% filter indent(8) %}
         {{ core(location['core']) }}
+{%- endfilter %}
+{% endif %}
+{% if location['http2'] is defined %}
+{% from 'http/modules.j2' import http2 with context %}
+{% filter indent(8) %}
+        {{ http2(location['http2'], 'location') }}
 {%- endfilter %}
 {% endif %}
 {% if location['app_protect_waf'] is defined %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -345,7 +345,7 @@ http2_body_preread_size {{ http2['body_preread_size'] }};
 http2_max_concurrent_streams {{ http2['max_concurrent_streams'] }};
 {% endif %}
 {% endif %}
-{% if scope == 'http' and http2['recv_buffer_size'] is defined %} {# can only be in 'http' context #}
+{% if scope == 'http' and http2['recv_buffer_size'] is defined %}{# 'recv_buffer_size' directive is only available in the 'http' context #}
 http2_recv_buffer_size {{ http2['recv_buffer_size'] }};
 {% endif %}
 {% if http2['chunk_size'] is defined %} {# can be wherever #}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -330,3 +330,26 @@ sub_filter_types {{ sub_filter['types'] if sub_filter['types'] is string else su
 {% endif %}
 
 {% endmacro %}
+
+{# NGINX HTTP v2 -- ngx_http_v2_module #}
+{% macro http2(http2, scope='http') %}
+{% if http2 is defined %}
+{% if scope != 'location' %} {# 'http' and 'server' contexts #}
+{% if http2['enabled'] is boolean and http2['enabled'] | bool %}
+http2 on;
+{% endif %}
+{% if http2['body_preread_size'] is defined %}
+http2_body_preread_size {{ http2['body_preread_size'] }};
+{% endif %}
+{% if http2['max_concurrent_streams'] is defined %}
+http2_max_concurrent_streams
+{% endif %}
+{% endif %}
+{% if scope == 'http' and http2['recv_buffer_size'] is defined %} {# can only be in 'http' context #}
+http2_recv_buffer_size {{ http2['http2_recv_buffer_size'] }};
+{% endif %}
+{% if http2['body_chunk_size'] %} {# can be wherever #}
+http2_chunk_size {{ http2['body_chunk_size'] }};
+{% endif %}
+{% endif %}
+{% endmacro%}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -348,7 +348,7 @@ http2_max_concurrent_streams {{ http2['max_concurrent_streams'] }};
 {% if scope == 'http' and http2['recv_buffer_size'] is defined %}{# 'recv_buffer_size' directive is only available in the 'http' context #}
 http2_recv_buffer_size {{ http2['recv_buffer_size'] }};
 {% endif %}
-{% if http2['chunk_size'] is defined %} {# can be wherever #}
+{% if http2['chunk_size'] is defined %}
 http2_chunk_size {{ http2['chunk_size'] }};
 {% endif %}
 {% endif %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -335,8 +335,8 @@ sub_filter_types {{ sub_filter['types'] if sub_filter['types'] is string else su
 {% macro http2(http2, scope='http') %}
 {% if http2 is defined %}
 {% if scope != 'location' %} {# 'http' and 'server' contexts #}
-{% if http2['enabled'] is boolean and http2['enabled'] | bool %}
-http2 on;
+{% if http2['enabled'] is boolean %}
+http2 {{ http2['enabled'] | ternary('on', 'off') }};
 {% endif %}
 {% if http2['body_preread_size'] is defined %}
 http2_body_preread_size {{ http2['body_preread_size'] }};

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -335,7 +335,7 @@ sub_filter_types {{ sub_filter['types'] if sub_filter['types'] is string else su
 {% macro http2(http2, scope='http') %}
 {% if http2 is defined %}
 {% if scope != 'location' %} {# 'http' and 'server' contexts #}
-{% if http2['enabled'] is boolean %}
+{% if http2['enabled'] is defined and http2['enabled'] is boolean %}
 http2 {{ http2['enabled'] | ternary('on', 'off') }};
 {% endif %}
 {% if http2['body_preread_size'] is defined %}
@@ -348,8 +348,8 @@ http2_max_concurrent_streams
 {% if scope == 'http' and http2['recv_buffer_size'] is defined %} {# can only be in 'http' context #}
 http2_recv_buffer_size {{ http2['recv_buffer_size'] }};
 {% endif %}
-{% if http2['body_chunk_size'] %} {# can be wherever #}
-http2_chunk_size {{ http2['body_chunk_size'] }};
+{% if http2['chunk_size'] is defined %} {# can be wherever #}
+http2_chunk_size {{ http2['chunk_size'] }};
 {% endif %}
 {% endif %}
 {% endmacro%}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -342,7 +342,7 @@ http2 {{ http2['enabled'] | ternary('on', 'off') }};
 http2_body_preread_size {{ http2['body_preread_size'] }};
 {% endif %}
 {% if http2['max_concurrent_streams'] is defined %}
-http2_max_concurrent_streams
+http2_max_concurrent_streams {{ http2['max_concurrent_streams'] }};
 {% endif %}
 {% endif %}
 {% if scope == 'http' and http2['recv_buffer_size'] is defined %} {# can only be in 'http' context #}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -352,4 +352,5 @@ http2_recv_buffer_size {{ http2['recv_buffer_size'] }};
 http2_chunk_size {{ http2['chunk_size'] }};
 {% endif %}
 {% endif %}
-{% endmacro%}
+
+{% endmacro %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -334,7 +334,7 @@ sub_filter_types {{ sub_filter['types'] if sub_filter['types'] is string else su
 {# NGINX HTTP v2 -- ngx_http_v2_module #}
 {% macro http2(http2, scope='http') %}
 {% if http2 is defined %}
-{% if scope != 'location' %} {# 'http' and 'server' contexts #}
+{% if scope != 'location' %}{# The following scoped directives are not available in the 'location' context #}
 {% if http2['enabled'] is defined and http2['enabled'] is boolean %}
 http2 {{ http2['enabled'] | ternary('on', 'off') }};
 {% endif %}

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -346,7 +346,7 @@ http2_max_concurrent_streams
 {% endif %}
 {% endif %}
 {% if scope == 'http' and http2['recv_buffer_size'] is defined %} {# can only be in 'http' context #}
-http2_recv_buffer_size {{ http2['http2_recv_buffer_size'] }};
+http2_recv_buffer_size {{ http2['recv_buffer_size'] }};
 {% endif %}
 {% if http2['body_chunk_size'] %} {# can be wherever #}
 http2_chunk_size {{ http2['body_chunk_size'] }};


### PR DESCRIPTION
### Proposed changes

Removes long abandoned SPDY listening socket option.
Also moves http2 to a server level 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
