### PR TITLE
Reload after ssl cert changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.1 (Unreleased)
+
+BUG FIXES:
+
+- Add handler to reload NGINX when SSL cert or key is changed.
+
 ## 0.7.0 (July 6, 2023)
 
 BREAKING CHANGES:

--- a/tasks/config/upload-config.yml
+++ b/tasks/config/upload-config.yml
@@ -54,6 +54,7 @@
         backup: "{{ item['backup'] | default(true) }}"
         mode: "0640"
       loop: "{{ nginx_config_upload_ssl_crt }}"
+      notify: (Handler - NGINX Config) Run NGINX
 
     - name: Upload NGINX SSL keys
       ansible.builtin.copy:
@@ -62,4 +63,5 @@
         backup: "{{ item['backup'] | default(true) }}"
         mode: "0640"
       loop: "{{ nginx_config_upload_ssl_key }}"
+      notify: (Handler - NGINX Config) Run NGINX
       no_log: true


### PR DESCRIPTION
### Proposed changes

Add handler to restart/reload nginx when SSL certs or keys change. Closes #318. When updating a SSL cert or keys, nginx needs to be reloaded before it will start serving the new cert. Otherwise the old (and potentially expired) cert will be used.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md))
