### PR TITLE
Fix incompatibility when using both `quic` and `so_keepalive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 0.7.2 (Unreleased)
+
+BUG FIXES:
+
+- Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
+
 ## 0.7.1 (October 3rd, 2023)
 
 ENHANCEMENTS:
 
-- Implement directives for the `http_v3` module. 
+- Implement directives for the `http_v3` module.
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -206,7 +206,7 @@ nginx_config_http_template:
             port: 80
             default_server: true  # Boolean
             ssl: false  # Boolean
-            quic: false  # Boolean
+            quic: false  # Boolean  # Incompatible with the 'so_keepalive' parameter
             proxy_protocol: false  # Boolean
             fastopen: 12  # Number
             backlog: 511  # Number
@@ -216,7 +216,7 @@ nginx_config_http_template:
             bind: false  # Boolean
             ipv6only: false  # Boolean
             reuseport: false  # Boolean
-            so_keepalive:  # false  # Can alternatively be set to a 'boolean'
+            so_keepalive:  # false  # Can alternatively be set to a 'boolean' -- Incompatible with the 'quic' parameter
               keepidle: 30m
               keepintvl: 5
               keepcnt: 10

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -582,14 +582,14 @@
                         ssl: false
                         quic: true
                         reuseport: true
-                        so_keepalive:
-                          keepidle: 30m
-                          keepintvl: 5
-                          keepcnt: 10
                       - address: "[::]"
                         port: 80
                         default_server: true
                         ssl: false
+                        so_keepalive:
+                          keepidle: 30m
+                          keepintvl: 5
+                          keepcnt: 10
                     open_file_cache: false
                     server_name: localhost
                     try_files:

--- a/templates/http/core.j2
+++ b/templates/http/core.j2
@@ -153,8 +153,8 @@ listen {{ listen['address'] if listen['address'] is defined }}{{ ':' if listen['
 {{- ' bind' if listen['bind'] is defined and listen['bind'] is boolean and listen['bind'] | bool -}}
 {{- (' ipv6only=' + listen['ipv6only'] | ternary('on', 'off')) if listen['ipv6only'] is defined and listen['ipv6only'] is boolean -}}
 {{- ' reuseport' if (listen['reuseport'] is defined and listen['reuseport'] is boolean and listen['reuseport'] | bool) -}}
-{{- (' so_keepalive=' + listen['so_keepalive'] | ternary('on', 'off')) if listen['so_keepalive'] is defined and listen['so_keepalive'] is boolean -}}
-{{- (' so_keepalive=' + (listen['so_keepalive']['keepidle'] | string if listen['so_keepalive']['keepidle'] is defined) + ':' + (listen['so_keepalive']['keepintvl'] | string if listen['so_keepalive']['keepintvl'] is defined) + ':' + (listen['so_keepalive']['keepcnt'] | string if listen['so_keepalive']['keepcnt'] is defined)) if listen['so_keepalive'] is defined and listen['so_keepalive'] is mapping }};
+{{- (' so_keepalive=' + listen['so_keepalive'] | ternary('on', 'off')) if listen['so_keepalive'] is defined and listen['so_keepalive'] is boolean and listen['quic'] is not defined -}}
+{{- (' so_keepalive=' + (listen['so_keepalive']['keepidle'] | string if listen['so_keepalive']['keepidle'] is defined) + ':' + (listen['so_keepalive']['keepintvl'] | string if listen['so_keepalive']['keepintvl'] is defined) + ':' + (listen['so_keepalive']['keepcnt'] | string if listen['so_keepalive']['keepcnt'] is defined)) if listen['so_keepalive'] is defined and listen['so_keepalive'] is mapping and listen['quic'] is not defined }};
 {% endfor %}
 {% endif %}
 {% if core['log_not_found'] is defined and core['log_not_found'] is boolean %}


### PR DESCRIPTION
### Proposed changes

Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CONTRIBUTING.md) document.
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] I have checked that any relevant Molecule tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-config/blob/main/CHANGELOG.md)).
