### PR TITLE
fix: Default path for stream template deployment location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FEATURES:
 
 BUG FIXES:
 
+- Fix path for the default stream template deployment location.
 - Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ FEATURES:
 
 BUG FIXES:
 
-- Fix path for the default stream template deployment location.
+- Fix the default path for the stream template deployment location.
 - Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
 

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -120,11 +120,11 @@
 - name: Dynamically generate NGINX stream config files
   ansible.builtin.template:
     src: "{{ item['template_file'] | default('stream/default.conf.j2') }}"
-    dest: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream_default.conf') }}"
+    dest: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream/stream_default.conf') }}"
     backup: true
     mode: "0644"
   loop: "{{ nginx_config_stream_template }}"
   loop_control:
-    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream_default.conf') }}"
+    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream/stream_default.conf') }}"
   notify: (Handler - NGINX Config) Run NGINX
   when: nginx_config_stream_template_enable | bool


### PR DESCRIPTION
### Proposed changes

Fix the default path for the stream template deployment location.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
