### PR TITLE
fix: Create path for stream template deployment location

### DIFF
--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -109,12 +109,12 @@
 
 - name: Ensure NGINX stream directory exists
   ansible.builtin.file:
-    path: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/') | dirname }}"
+    path: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream') | dirname }}"
     state: directory
     mode: "0755"
   loop: "{{ nginx_config_stream_template }}"
   loop_control:
-    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/') | dirname }}"
+    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream') | dirname }}"
   when: nginx_config_stream_template_enable | bool
 
 - name: Dynamically generate NGINX stream config files

--- a/tasks/config/template-config.yml
+++ b/tasks/config/template-config.yml
@@ -109,12 +109,12 @@
 
 - name: Ensure NGINX stream directory exists
   ansible.builtin.file:
-    path: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream') | dirname }}"
+    path: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream/') | dirname }}"
     state: directory
     mode: "0755"
   loop: "{{ nginx_config_stream_template }}"
   loop_control:
-    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream') | dirname }}"
+    label: "{{ item['deployment_location'] | default('/etc/nginx/conf.d/stream/') | dirname }}"
   when: nginx_config_stream_template_enable | bool
 
 - name: Dynamically generate NGINX stream config files


### PR DESCRIPTION
### Proposed changes

#479 didn't quite fix the stream template path bug. Let's try again.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
