### PR TITLE
Check mode false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 - Fix the default path for the stream template deployment location.
 - Fix incompatibility when using the `listen` directive and setting both the `quic` and `so_keepalive` parameters.
 - Correct cleanup error when `nginx_config_cleanup_paths` is not defined.
+- Disable check_mode for validation task `jinja2_version`.
 
 TESTS:
 

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -13,6 +13,7 @@
   changed_when: false
   delegate_to: localhost
   become: false
+  check_mode: false
 
 - name: Verify that you are using a supported Jinja2 version on your Ansible host
   ansible.builtin.assert:


### PR DESCRIPTION
### Proposed changes

```
TASK [nginx_config : Verify that you are using a supported Jinja2 version on your Ansible host] ********************************************************************************
fatal: [scar2 -> localhost]: FAILED! => {"msg": "Unexpected templating type error occurred on (Jinja2 {{ jinja2_version['stdout'] | regex_search('jinja version = ([\\\\d.]+)', '\\\\1') | first }} is supported.): 'NoneType' object is not iterable. 'NoneType' object is not iterable"}
```
Ansible check mode was failing to due the empty `jinja2_version` variable. Added `check_mode: false` to make it pass


### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
