### PR TITLE
feat: Add `uwsgi` template support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 - Add validation tasks to check the Ansible version, the Jinja2 version, and whether the required Ansible collections for this role are installed.
 - Bump the Ansible `community.general` collection to `9.2.0`, `community.crypto` collection to `2.21.1` and `community.docker` collection to `3.11.0`.
 - Add templating support for the `ngx_mgmt_module`, `ngx_http_gzip_static_module`, and `ngx_stream_map_module` NGINX modules.
+- Now support uwsgi using the uwsgi_pass directive
 
 BUG FIXES:
 

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -293,6 +293,8 @@ nginx_config_http_template:
         underscores_in_headers: false  # Boolean -- Not available in the 'location' context
         variables_hash_bucket_size: 64  # Available only in the 'http' context
         variables_hash_max_size: 1024  # Available only in the 'http' context
+      uwsgi:
+        pass: upstreamserver
       http2:  # Configure HTTP2
         enable: false  # Boolean -- Not available in the 'location' context
         body_preread_size: 64k  # Not available in the 'location' context

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -309,6 +309,12 @@ server {
         {{ core(location['core']) }}
 {%- endfilter %}
 {% endif %}
+{% if location['uwsgi'] is defined %}
+{% from 'http/uwsgi.j2' import uwsgi with context %}
+{% filter indent(8) %}
+        {{ uwsgi(location['uwsgi']) }}
+{%- endfilter %}
+{% endif %}
 {% if location['http2'] is defined %}
 {% from 'http/modules.j2' import http2 with context %}
 {% filter indent(8) %}

--- a/templates/http/uwsgi.j2
+++ b/templates/http/uwsgi.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed | comment }}
+
+{% if uwsgi['pass'] is defined %}
+uwsgi_pass {{ uwsgi['pass'] }}
+{% endif %}


### PR DESCRIPTION
### Proposed changes

Anyone who wants to use uwsgi has to edit their configuration after deploying using nginx_config because the uwsgi_pass directive is not supported by this role.

This change will allow specifying the uwsgi_pass directive from within the role, eliminating the need to patch up the configuration file after the fact.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
