### PR TITLE
variable name collision for setting logs

### DIFF
--- a/tasks/config/upload-config.yml
+++ b/tasks/config/upload-config.yml
@@ -52,7 +52,7 @@
         src: "{{ item['src'] }}"
         dest: "{{ item['dest'] | default('/etc/ssl/certs') }}"
         backup: "{{ item['backup'] | default(true) }}"
-        mode: "0640"
+        mode: "0644"
       loop: "{{ nginx_config_upload_ssl_crt }}"
       notify: (Handler - NGINX Config) Run NGINX
 

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -187,20 +187,20 @@ log_format {{ format['name'] }}{{ (' escape=' + format['escape'] | string) if fo
 {% if log['access'] is defined and log['access'] is boolean and not log['access'] | bool %}
 access_log {{ 'off' }};
 {% elif log['access'] is defined %}
-{% for log in log['access'] %}
-access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (' ' + log['format'] | string) if log['format'] is defined -}}
-{{- (' buffer=' + log['buffer'] | string) if log['buffer'] is defined -}}
-{{- ' gzip' if log['gzip'] is defined and log['access']['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and log['gzip'] is string -}}
-{{- (' flush=' + log['flush'] | string) if log['flush'] is defined -}}
-{{- (' if=' + log['if']) if log['if'] is defined }};
+{% for access_item in log['access'] %}
+access_log {{ 'off' if not access_item else access_item['path'] if access_item['path'] is defined }}{{ (' ' + access_item['format'] | string) if access_item['format'] is defined -}}
+{{- (' buffer=' + access_item['buffer'] | string) if access_item['buffer'] is defined -}}
+{{- ' gzip' if access_item['gzip'] is defined and access_item['gzip'] is boolean and access_item['gzip'] | bool else (' gzip=' + access_item['gzip'] | string) if access_item['gzip'] is defined -}}
+{{- (' flush=' + access_item['flush'] | string) if access_item['flush'] is defined -}}
+{{- (' if=' + access_item['if']) if access_item['if'] is defined }};
 {% endfor %}
 {% endif %}
 {% if log['error'] is defined %}{# This does not belong here but we are making an exception #}
-{% for log in log['error'] if (log['error'] is not mapping and log['error'] is not string) %}
-error_log {{ log if log is string else log['file'] }}{{ (' ' + log['level'] | string) if log['level'] is defined }};
+{% for error_item in log['error'] if (log['error'] is not mapping and log['error'] is not string) %}
+error_log {{ error_item if error_item is string else error_item['file'] }}{{ (' ' + error_item['level'] | string) if error_item['level'] is defined }};
+{% endfor %}
 {% else %}
 error_log {{ log['error'] if log['error'] is string else log['error']['file'] }}{{ (' ' + log['error']['level'] | string) if log['error']['level'] is defined }};
-{% endfor %}
 {% endif %}
 {% if log['open_log_file_cache'] is defined %}
 open_log_file_cache {{ 'off' if not log['open_log_file_cache'] else ('max=' + log['open_log_file_cache']['max'] | string) }}{{ (' inactive=' + log['open_log_file_cache']['inactive'] | string) if log['open_log_file_cache']['inactive'] is defined }}{{ (' min_uses=' + log['open_log_file_cache']['min_uses'] | string) if log['open_log_file_cache']['min_uses'] is defined and log['open_log_file_cache']['min_uses'] is number }}{{ (' valid=' + log['open_log_file_cache']['valid'] | string) if log['open_log_file_cache']['valid'] is defined }};

--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -198,9 +198,9 @@ access_log {{ 'off' if not access_item else access_item['path'] if access_item['
 {% if log['error'] is defined %}{# This does not belong here but we are making an exception #}
 {% for error_item in log['error'] if (log['error'] is not mapping and log['error'] is not string) %}
 error_log {{ error_item if error_item is string else error_item['file'] }}{{ (' ' + error_item['level'] | string) if error_item['level'] is defined }};
-{% endfor %}
 {% else %}
 error_log {{ log['error'] if log['error'] is string else log['error']['file'] }}{{ (' ' + log['error']['level'] | string) if log['error']['level'] is defined }};
+{% endfor %}
 {% endif %}
 {% if log['open_log_file_cache'] is defined %}
 open_log_file_cache {{ 'off' if not log['open_log_file_cache'] else ('max=' + log['open_log_file_cache']['max'] | string) }}{{ (' inactive=' + log['open_log_file_cache']['inactive'] | string) if log['open_log_file_cache']['inactive'] is defined }}{{ (' min_uses=' + log['open_log_file_cache']['min_uses'] | string) if log['open_log_file_cache']['min_uses'] is defined and log['open_log_file_cache']['min_uses'] is number }}{{ (' valid=' + log['open_log_file_cache']['valid'] | string) if log['open_log_file_cache']['valid'] is defined }};


### PR DESCRIPTION
### Proposed changes

- Change public cert permission
- Fix variable name collision 

Change the permission for the uploaded public certificate to `0644` because certain applications try to read the whole `/etc/ssl/certs` directory and throw warnings if some certs can't be read.

Resolve template error where loop variables log were shadowing the parent log dictionary, causing "object of type 'str' has no attribute 'error'" failures. Changed loop variable names to access_item and error_item to avoid naming conflicts. Don't enforce gzip variable to be a string.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
