### PR TITLE
Fix rewrite variable name collision

### DIFF
--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -279,10 +279,10 @@ real_ip_recursive {{ realip['real_ip_recursive'] | ternary('on', 'off') }};
 return {{ rewrite['return'] if (rewrite['return'] is string or rewrite['return'] is number) }}{{ rewrite['return']['code'] if rewrite['return']['code'] is defined }}{{ (' ' + rewrite['return']['text'] | string) if rewrite['return']['text'] is defined }}{{ (' ' + rewrite['return']['url'] | string) if rewrite['return']['url'] is defined }};
 {% endif %}
 {% if rewrite['rewrites'] is defined %}{# 'rewrite' directive is not available in the 'http' context #}
-{% for rewrite in rewrite['rewrites'] if rewrite['rewrites'] is not mapping %}
-rewrite {{ rewrite['regex'] }} {{ rewrite['replacement'] }}{{ (' ' + rewrite['flag'] | string) if rewrite['flag'] is defined and rewrite['flag'] in ['last', 'break', 'redirect', 'permanent'] }};
+{% for rewrite_item in rewrite['rewrites'] if rewrite['rewrites'] is not mapping %}
+rewrite {{ rewrite_item['regex'] }} {{ rewrite_item['replacement'] }}{{ (' ' + rewrite_item['flag'] | string) if rewrite_item['flag'] is defined and rewrite_item['flag'] in ['last', 'break', 'redirect', 'permanent'] }};
 {% else %}
-rewrite {{ rewrite['rewrites']['regex'] }} {{ rewrite['rewrites']['replacement'] }}{{ (' ' + rewrite['rewrites']['flag'] | string) if rewrite['rewrites']['flag'] is defined and rewrite['rewrites']['flag'] in ['last', 'break', 'redirect', 'permanent'] }};
+rewrite {{ rewrite_item['rewrites']['regex'] }} {{ rewrite_item['rewrites']['replacement'] }}{{ (' ' + rewrite_item['rewrites']['flag'] | string) if rewrite_item['rewrites']['flag'] is defined and rewrite_item['rewrites']['flag'] in ['last', 'break', 'redirect', 'permanent'] }};
 {% endfor %}
 {% endif %}
 {% if rewrite['log'] is defined and rewrite['log'] is boolean %}


### PR DESCRIPTION
### Proposed changes

- Rename `rewrites` loop variable to prevent name collision

Resolves `object of type 'dict' has no attribute 'rewrites' ` error when specifying rewrites. Error is due to re-use of the variable name `rewrite` within the loop, causing a naming collision. Changed loop variable to `rewrite_item`

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
