### PR TITLE
fix(log): fix typo in log macro accessing non-existent 'access' key

### DIFF
--- a/templates/http/modules.j2
+++ b/templates/http/modules.j2
@@ -190,7 +190,7 @@ access_log {{ 'off' }};
 {% for log in log['access'] %}
 access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (' ' + log['format'] | string) if log['format'] is defined -}}
 {{- (' buffer=' + log['buffer'] | string) if log['buffer'] is defined -}}
-{{- ' gzip' if log['gzip'] is defined and log['access']['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and log['gzip'] is string -}}
+{{- ' gzip' if log['gzip'] is defined and log['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and (log['gzip'] is string or log['gzip'] is number) -}}
 {{- (' flush=' + log['flush'] | string) if log['flush'] is defined -}}
 {{- (' if=' + log['if']) if log['if'] is defined }};
 {% endfor %}

--- a/templates/stream/modules.j2
+++ b/templates/stream/modules.j2
@@ -62,7 +62,7 @@ access_log {{ 'off' }};
 {% for log in log['access'] %}
 access_log {{ 'off' if not log else log['path'] if log['path'] is defined }}{{ (' ' + log['format'] | string) if log['format'] is defined -}}
 {{- (' buffer=' + log['buffer'] | string) if log['buffer'] is defined -}}
-{{- ' gzip' if log['gzip'] is defined and log['access']['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and log['gzip'] is string -}}
+{{- ' gzip' if log['gzip'] is defined and log['gzip'] is boolean and log['gzip'] | bool else (' gzip=' + log['gzip'] | string) if log['gzip'] is defined and (log['gzip'] is string or log['gzip'] is number) -}}
 {{- (' flush=' + log['flush'] | string) if log['flush'] is defined -}}
 {{- (' if=' + log['if']) if log['if'] is defined }};
 {% endfor %}


### PR DESCRIPTION
Inside the 'log' macro, the template iterates over log['access'] entries using '{% for log in log['access'] %}'. Within this loop, each 'log' is an individual access log entry dict with keys: path, format, buffer, gzip, flush, if.

The gzip conditional on line 193 (http) / line 65 (stream) contained a typo: it accessed log['access']['gzip'] instead of log['gzip']. Since entry dicts have no 'access' key, this caused an UndefinedError in Jinja2 3.x (which no longer silently returns Undefined for missing dict keys).

Additionally, the condition only handled string values for gzip, but the defaults document gzip can be a number (e.g., 'gzip: 5'). The condition now also accepts numeric types.

Fixes: log['access']['gzip'] -> log['gzip']
Adds: (log['gzip'] is string or log['gzip'] is number)

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
